### PR TITLE
Removing newtonsoft json and using System.Text.Json instead

### DIFF
--- a/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
+++ b/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
@@ -8,13 +8,14 @@
         <Folder Include="Models\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-preview1" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview1" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview1" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview1" />
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview1" />
+        <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview4" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Material.Icons.Avalonia\Material.Icons.Avalonia.csproj" />
+      <ProjectReference Include="..\Material.Icons\Material.Icons.csproj" />
     </ItemGroup>
 </Project>

--- a/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
+++ b/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
@@ -17,7 +17,7 @@
         <PackageVersion>1.2.0</PackageVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-preview1" />
+        <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Material.Icons\Material.Icons.csproj" />

--- a/Material.Icons.Gen/Material.Icons.Gen.csproj
+++ b/Material.Icons.Gen/Material.Icons.Gen.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="System.Text.Json" Version="7.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Material.Icons.Gen/Material.Icons.Gen.csproj
+++ b/Material.Icons.Gen/Material.Icons.Gen.csproj
@@ -2,23 +2,20 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <Compile Include="..\Material.Icons\ExtensionMethods.cs">
-        <Link>Linked\ExtensionMethods.cs</Link>
-      </Compile>
-      <Compile Include="..\Material.Icons\MaterialIconInfo.cs">
-        <Link>Linked\MaterialIconInfo.cs</Link>
-      </Compile>
-      <Compile Include="..\Material.Icons\MaterialIconUser.cs">
-        <Link>Linked\MaterialIconUser.cs</Link>
-      </Compile>
-      <Compile Include="..\Material.Icons\MetaMaterialIcons.cs">
-        <Link>Linked\MetaMaterialIcons.cs</Link>
-      </Compile>
+        <Compile Include="..\Material.Icons\ExtensionMethods.cs">
+            <Link>Linked\ExtensionMethods.cs</Link>
+        </Compile>
+        <Compile Include="..\Material.Icons\MaterialIconInfo.cs">
+            <Link>Linked\MaterialIconInfo.cs</Link>
+        </Compile>
+        <Compile Include="..\Material.Icons\MaterialIconUser.cs">
+            <Link>Linked\MaterialIconUser.cs</Link>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/Material.Icons.Gen/MaterialIconsMetaTools.cs
+++ b/Material.Icons.Gen/MaterialIconsMetaTools.cs
@@ -3,15 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
-using Material.Icons;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Material.Icons.Gen {
     public static class MaterialIconsMetaTools {
         public static IEnumerable<MaterialIconInfo> GetIcons() {
             using var webClient = new WebClient();
             var data = webClient.DownloadString("https://materialdesignicons.com/api/package/38EF63D0-4744-11E4-B3CF-842B2B6CFE1B");
-            var icons = JsonConvert.DeserializeObject<MetaMaterialIcons>(data).Icons;
+            var icons = JsonSerializer.Deserialize<MetaMaterialIcons>(data).Icons;
             var iconsByName = new Dictionary<string, MaterialIconInfo>(StringComparer.OrdinalIgnoreCase);
             foreach (var icon in icons.Where(icon => !iconsByName.ContainsKey(icon.Name))) {
                 iconsByName.Add(icon.Name, icon);

--- a/Material.Icons.Gen/MaterialIconsMetaTools.cs
+++ b/Material.Icons.Gen/MaterialIconsMetaTools.cs
@@ -2,15 +2,21 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Material.Icons.Gen {
     public static class MaterialIconsMetaTools {
         public static IEnumerable<MaterialIconInfo> GetIcons() {
-            using var webClient = new WebClient();
-            var data = webClient.DownloadString("https://materialdesignicons.com/api/package/38EF63D0-4744-11E4-B3CF-842B2B6CFE1B");
-            var icons = JsonSerializer.Deserialize<MetaMaterialIcons>(data).Icons;
+            using var webClient = new HttpClient();
+            var dataString = webClient.GetStringAsync("https://materialdesignicons.com/api/package/38EF63D0-4744-11E4-B3CF-842B2B6CFE1B").Result;
+            var data = JsonSerializer.Deserialize<MetaMaterialIcons>(dataString, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+            var icons = data.Icons;
             var iconsByName = new Dictionary<string, MaterialIconInfo>(StringComparer.OrdinalIgnoreCase);
             foreach (var icon in icons.Where(icon => !iconsByName.ContainsKey(icon.Name))) {
                 iconsByName.Add(icon.Name, icon);

--- a/Material.Icons.Gen/MetaMaterialIcons.cs
+++ b/Material.Icons.Gen/MetaMaterialIcons.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 namespace Material.Icons {
     internal class MetaMaterialIcons
     {
-        [JsonPropertyName("icons")]
         public List<MaterialIconInfo> Icons { get; set; }
     }
 }

--- a/Material.Icons.Gen/Program.cs
+++ b/Material.Icons.Gen/Program.cs
@@ -40,7 +40,7 @@ namespace Material.Icons.Gen {
         public static void GenerateDataFactory(List<MaterialIconInfo> materialIconInfos) {
             var stringBuilder = new StringBuilder();
 
-            stringBuilder.AppendLine("using System;\nusing System.Collections.Generic;\nusing Newtonsoft.Json;\nusing Material.Icons;");
+            stringBuilder.AppendLine("using System;\nusing System.Collections.Generic;\nusing Material.Icons;");
             stringBuilder.AppendLine(
                 "namespace Material.Icons\n{\n    /// ******************************************\n    /// This code is auto generated. Do not amend.\n    /// ******************************************");
             stringBuilder.AppendLine(
@@ -51,13 +51,19 @@ namespace Material.Icons.Gen {
             }
 
             stringBuilder.AppendLine(
-                "         };\n\n        public static IDictionary<MaterialIconKind, MaterialIconInfo> InstanceSetCreate() => new Dictionary<MaterialIconKind, MaterialIconInfo> {");
+                "         };\n\n");
 
+            // Start InstanceSetCreate
+            stringBuilder.AppendLine(
+                "        public static IDictionary<MaterialIconKind, MaterialIconInfo> InstanceSetCreate() => new Dictionary<MaterialIconKind, MaterialIconInfo> {");
             foreach (var info in materialIconInfos) {
                 stringBuilder.AppendLine($"            {{MaterialIconKind.{info.Name}, {MaterialIconsMetaTools.SerializeIcon(info)}}},");
             }
 
-            stringBuilder.AppendLine("\n        };\n    }\n}");
+            stringBuilder.AppendLine("\n        };\n");
+            // End InstanceSetCreate
+            
+            stringBuilder.AppendLine("    }\n}");
 
             File.Delete("MaterialIconDataFactory.cs");
             File.WriteAllText("MaterialIconDataFactory.cs", stringBuilder.ToString());

--- a/Material.Icons/Material.Icons.csproj
+++ b/Material.Icons/Material.Icons.csproj
@@ -15,7 +15,7 @@
         <PackageReleaseNotes>- Icons set updated according to materialdesignicons.com at Fri Dec 30 00:44:23 UTC 2022</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="System.Text.Json" Version="7.0.1" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Material.Icons/Material.Icons.csproj
+++ b/Material.Icons/Material.Icons.csproj
@@ -14,9 +14,6 @@
         <Version>1.1.31</Version>
         <PackageReleaseNotes>- Icons set updated according to materialdesignicons.com at Fri Dec 30 00:44:23 UTC 2022</PackageReleaseNotes>
     </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="System.Text.Json" Version="7.0.1" />
-    </ItemGroup>
 
     <PropertyGroup>
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">../</SolutionDir>

--- a/Material.Icons/MaterialIconInfo.cs
+++ b/Material.Icons/MaterialIconInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Material.Icons {
     public class MaterialIconInfo {
@@ -8,26 +8,26 @@ namespace Material.Icons {
 
         public List<string> Aliases { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         private string SourceName {
             set => Name = value?.Underscore().Pascalize();
         }
 
-        [JsonProperty("aliases")]
+        [JsonPropertyName("aliases")]
         private List<string> SourceAliases {
             set => Aliases = value.Select(s => s.Underscore().Pascalize()).ToList();
         }
 
-        [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public string Data { get; set; }
 
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public MaterialIconUser User { get; set; }
 
-        [JsonProperty("commentCount")]
+        [JsonPropertyName("commentCount")]
         public long CommentCount { get; set; }
     }
 }

--- a/Material.Icons/MaterialIconInfo.cs
+++ b/Material.Icons/MaterialIconInfo.cs
@@ -1,33 +1,29 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
 
 namespace Material.Icons {
     public class MaterialIconInfo {
-        public string Name { get; set; }
+        private string _name;
+        private List<string> _aliases;
+        
+        public string Name
+        {
+            get => _name;
+            set => _name = value?.Underscore().Pascalize();
+        }
 
-        public List<string> Aliases { get; set; }
-
-        [JsonPropertyName("id")]
+        public List<string> Aliases
+        {
+            get => _aliases;
+            set => _aliases = value.Select(s => s.Underscore().Pascalize()).ToList();
+        }
+        
         public string Id { get; set; }
-
-        [JsonPropertyName("name")]
-        private string SourceName {
-            set => Name = value?.Underscore().Pascalize();
-        }
-
-        [JsonPropertyName("aliases")]
-        private List<string> SourceAliases {
-            set => Aliases = value.Select(s => s.Underscore().Pascalize()).ToList();
-        }
-
-        [JsonPropertyName("data")]
+        
         public string Data { get; set; }
-
-        [JsonPropertyName("user")]
+        
         public MaterialIconUser User { get; set; }
-
-        [JsonPropertyName("commentCount")]
+        
         public long CommentCount { get; set; }
     }
 }

--- a/Material.Icons/MaterialIconUser.cs
+++ b/Material.Icons/MaterialIconUser.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Material.Icons {
     public class MaterialIconUser
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/Material.Icons/MaterialIconUser.cs
+++ b/Material.Icons/MaterialIconUser.cs
@@ -1,12 +1,10 @@
-﻿using System.Text.Json.Serialization;
+﻿
 
 namespace Material.Icons {
     public class MaterialIconUser
     {
-        [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/Material.Icons/MetaMaterialIcons.cs
+++ b/Material.Icons/MetaMaterialIcons.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Material.Icons {
     internal class MetaMaterialIcons
     {
-        [JsonProperty("icons")]
+        [JsonPropertyName("icons")]
         public List<MaterialIconInfo> Icons { get; set; }
     }
 }


### PR DESCRIPTION
System.Text.Json is becoming the standard on newer C# project so i think it is a good idea to remove one less dependency when using Material.Icons