### PR TITLE
Revert the change of ItemGroups for avalonia projects

### DIFF
--- a/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
+++ b/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
@@ -6,6 +6,13 @@
     </PropertyGroup>
     <ItemGroup>
         <Folder Include="Models\" />
+        <Compile Update="**\*.xaml.cs">
+            <DependentUpon>%(Filename)</DependentUpon>
+        </Compile>
+        <AvaloniaResource Include="**\*.xaml">
+            <SubType>Designer</SubType>
+        </AvaloniaResource>
+        <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.0-preview4" />

--- a/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
+++ b/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
@@ -18,6 +18,14 @@
         <PackageReleaseNotes>Removed Newtonsoft.Json dependency</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>
+        <Compile Update="**\*.xaml.cs">
+            <DependentUpon>%(Filename)</DependentUpon>
+        </Compile>
+        <AvaloniaResource Include="**\*.xaml">
+            <SubType>Designer</SubType>
+        </AvaloniaResource>
+    </ItemGroup>
+    <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.0-preview1" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
I got exception ` Avalonia.Markup.Xaml.XamlLoadException: No precompiled XAML found for avares://Material.Icons.Avalonia/App.xaml (baseUri: avares://Material.Icons.Avalonia.Demo/App.xaml), make sure to specify x:Class and include your XAML file as AvaloniaResource
` when runuing the sample `Material.Icons.Avalonia.Demo` 

It need to revert the change of ItemGroups for avalonia projects