### PR TITLE
Allow overriding the provider's static instance

### DIFF
--- a/Material.Icons/MaterialIconDataProvider.Declaration.cs
+++ b/Material.Icons/MaterialIconDataProvider.Declaration.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Material.Icons;
 
 /// ******************************************
@@ -8,15 +10,23 @@ namespace Material.Icons;
 /// </summary>
 public partial class MaterialIconDataProvider {
     private static MaterialIconDataProvider? _instance;
+
     /// <summary>
-    /// Gets the singleton instance of this provider
+    /// Gets or sets the singleton instance of this provider
     /// </summary>
-    public static MaterialIconDataProvider Instance => _instance ??= new MaterialIconDataProvider();
+    public static MaterialIconDataProvider Instance {
+        get => _instance;
+        set {
+            _instance = value ?? throw new ArgumentNullException(nameof(value));
+        }
+    }
+
     /// <summary>
     /// Gets the data for the specified icon using the <see cref="Instance"/>
     /// </summary>
     /// <param name="kind">The icon kind</param>
     /// <returns>SVG path for target icon kind</returns>
+
     public static string GetData(MaterialIconKind kind) => Instance.ProvideData(kind);
     /// <summary>
     /// Provides the data for the specified icon kind

--- a/Material.Icons/MaterialIconDataProvider.Declaration.cs
+++ b/Material.Icons/MaterialIconDataProvider.Declaration.cs
@@ -9,7 +9,7 @@ namespace Material.Icons;
 /// Allows retrieving data for icons
 /// </summary>
 public partial class MaterialIconDataProvider {
-    private static MaterialIconDataProvider? _instance;
+    private static MaterialIconDataProvider _instance = new();
 
     /// <summary>
     /// Gets or sets the singleton instance of this provider

--- a/build/Generators/MaterialIconDataDeclarationGenerator.cs
+++ b/build/Generators/MaterialIconDataDeclarationGenerator.cs
@@ -9,8 +9,10 @@ public class MaterialIconDataDeclarationGenerator {
     public static void Write(AbsolutePath destinationPath) {
         var path = destinationPath / "MaterialIconDataProvider.Declaration.cs";
         Log.Information("Writing declaration for material icons data to {Path}", path);
-
+        
         var stringBuilder = new StringBuilder();
+        stringBuilder.AppendLine("using System;");
+        stringBuilder.AppendLine("");
         stringBuilder.AppendLine("namespace Material.Icons;");
         stringBuilder.AppendLine("");
         stringBuilder.AppendLine("/// ******************************************");
@@ -21,15 +23,23 @@ public class MaterialIconDataDeclarationGenerator {
         stringBuilder.AppendLine("/// </summary>");
         stringBuilder.AppendLine("public partial class MaterialIconDataProvider {");
         stringBuilder.AppendLine("    private static MaterialIconDataProvider? _instance;");
+        stringBuilder.AppendLine("");
         stringBuilder.AppendLine("    /// <summary>");
-        stringBuilder.AppendLine("    /// Gets the singleton instance of this provider");
+        stringBuilder.AppendLine("    /// Gets or sets the singleton instance of this provider");
         stringBuilder.AppendLine("    /// </summary>");
-        stringBuilder.AppendLine("    public static MaterialIconDataProvider Instance => _instance ??= new MaterialIconDataProvider();");
+        stringBuilder.AppendLine("    public static MaterialIconDataProvider Instance {");
+        stringBuilder.AppendLine("        get => _instance;");
+        stringBuilder.AppendLine("        set {");
+        stringBuilder.AppendLine("            _instance = value ?? throw new ArgumentNullException(nameof(value));");
+        stringBuilder.AppendLine("        }");
+        stringBuilder.AppendLine("    }");
+        stringBuilder.AppendLine("");
         stringBuilder.AppendLine("    /// <summary>");
         stringBuilder.AppendLine("    /// Gets the data for the specified icon using the <see cref=\"Instance\"/>");
         stringBuilder.AppendLine("    /// </summary>");
         stringBuilder.AppendLine("    /// <param name=\"kind\">The icon kind</param>");
         stringBuilder.AppendLine("    /// <returns>SVG path for target icon kind</returns>");
+        stringBuilder.AppendLine("");
         stringBuilder.AppendLine("    public static string GetData(MaterialIconKind kind) => Instance.ProvideData(kind);");
         stringBuilder.AppendLine("    /// <summary>");
         stringBuilder.AppendLine("    /// Provides the data for the specified icon kind");

--- a/build/Generators/MaterialIconDataDeclarationGenerator.cs
+++ b/build/Generators/MaterialIconDataDeclarationGenerator.cs
@@ -22,7 +22,7 @@ public class MaterialIconDataDeclarationGenerator {
         stringBuilder.AppendLine("/// Allows retrieving data for icons");
         stringBuilder.AppendLine("/// </summary>");
         stringBuilder.AppendLine("public partial class MaterialIconDataProvider {");
-        stringBuilder.AppendLine("    private static MaterialIconDataProvider? _instance;");
+        stringBuilder.AppendLine("    private static MaterialIconDataProvider _instance = new();");
         stringBuilder.AppendLine("");
         stringBuilder.AppendLine("    /// <summary>");
         stringBuilder.AppendLine("    /// Gets or sets the singleton instance of this provider");


### PR DESCRIPTION
This allows package consumers to override some icons by setting the data provider.  

The provider instance cannot be null.  Attempting to set the provider instance to null will throw an `ArgumentNullException`.

It can be used as:

```
public class CustomIconProvider : MaterialIconDataProvider
{
    public override string ProvideData(MaterialIconKind kind)
    {
        return kind switch
        {
            MaterialIconKind.TrophyVariant => "some SVG code",
            _ => base.ProvideData(kind)
        };
    }
}

internal static class Program
{
    public static int Main(string[] args)
    {
        MaterialIconDataProvider.Instance = new CustomIconProvider(); // use custom icons

        return BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
    }
}
```
