### PR TITLE
remove explicit packageversion from avaloia project

### DIFF
--- a/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
+++ b/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
@@ -15,7 +15,6 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <PackageTags>material icons material-design google-material avalonia</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>2.1.0</PackageVersion>
     <PackageReleaseNotes>- Icons set updated according to materialdesignicons.com at Thu, 04 Apr 2024 12:16:53 GMT
 Check out changes at https://pictogrammers.com/library/mdi/history/</PackageReleaseNotes>
     <Version>2.1.9</Version>


### PR DESCRIPTION
Since there was an explicit PackageVersion defined the version (2.1.9) in the latest build would not be used when creating the nuget. Now it should update the avalonia package as well.

For WPF the correct version is created:
![image](https://github.com/SKProCH/Material.Icons/assets/13013397/a05b8aa6-abc9-4e88-a84e-ede7d3dd9768)

For Avalonia the version is not used because PackageVersion was defined:
![image](https://github.com/SKProCH/Material.Icons/assets/13013397/2c3c003f-8dae-4794-84f9-b89c65ed4980)

related to the last pr: #30 