### PR TITLE
MaterialIconText templated control

### DIFF
--- a/Material.Icons.Avalonia/MaterialIconStyles.axaml
+++ b/Material.Icons.Avalonia/MaterialIconStyles.axaml
@@ -6,6 +6,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Material.Icons.Avalonia/MaterialIcon.axaml" />
+        <ResourceInclude Source="avares://Material.Icons.Avalonia/MaterialIconText.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </icons:MaterialIconStyles.Resources>

--- a/Material.Icons.Avalonia/MaterialIconText.axaml
+++ b/Material.Icons.Avalonia/MaterialIconText.axaml
@@ -1,0 +1,58 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:avalonia="clr-namespace:Material.Icons.Avalonia">
+  <Design.PreviewWith>
+    <StackPanel Spacing="10" Margin="10">
+      <avalonia:MaterialIconText Kind="Mountain" Text="Icon with text!"/>
+      <avalonia:MaterialIconText Kind="Mountain" TextFirst="True" Text="with text first"/>
+      <avalonia:MaterialIconText Kind="Mountain" IsTextSelectable="True" Text="or selectable"/>
+      <avalonia:MaterialIconText Kind="Mountain" TextFirst="True" IsTextSelectable="True" Text="or both"/>
+      <Button Content="{avalonia:MaterialIconTextExt Kind=Mountain, Text=and via extension}"/>
+    </StackPanel>
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type avalonia:MaterialIconText}" TargetType="avalonia:MaterialIconText">
+    <Setter Property="Spacing" Value="5"/>
+    <Setter Property="Orientation" Value="Horizontal"/>
+    <Setter Property="IconSize" Value="16"/>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <StackPanel Orientation="{TemplateBinding Orientation}"
+                    Spacing="{TemplateBinding Spacing}">
+          <avalonia:MaterialIcon Name="LeftIcon"
+                                 Kind="{TemplateBinding Kind}"
+                                 Width="{TemplateBinding IconSize}"
+                                 Height="{TemplateBinding IconSize}"/>
+          <TextBlock Text="{TemplateBinding Text}"
+                     HorizontalAlignment="Center"
+                     VerticalAlignment="Center"/>
+          <SelectableTextBlock Text="{TemplateBinding Text}"
+                               IsVisible="False"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"/>
+          <avalonia:MaterialIcon Name="RightIcon"
+                                 Kind="{TemplateBinding Kind}"
+                                 Width="{TemplateBinding IconSize}"
+                                 Height="{TemplateBinding IconSize}"
+                                 IsVisible="False"/>
+        </StackPanel>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^[TextFirst=True]">
+      <Style Selector="^ /template/ avalonia|MaterialIcon#LeftIcon">
+        <Setter Property="IsVisible" Value="False"/>
+      </Style>
+      <Style Selector="^ /template/ avalonia|MaterialIcon#RightIcon">
+        <Setter Property="IsVisible" Value="True"/>
+      </Style>
+    </Style>
+    <Style Selector="^[IsTextSelectable=True]">
+      <Style Selector="^ /template/ TextBlock">
+        <Setter Property="IsVisible" Value="False"/>
+      </Style>
+      <Style Selector="^ /template/ SelectableTextBlock">
+        <Setter Property="IsVisible" Value="True"/>
+      </Style>
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>

--- a/Material.Icons.Avalonia/MaterialIconText.axaml.cs
+++ b/Material.Icons.Avalonia/MaterialIconText.axaml.cs
@@ -22,31 +22,49 @@ namespace Material.Icons.Avalonia {
         public static readonly StyledProperty<double> IconSizeProperty =
             AvaloniaProperty.Register<MaterialIconText, double>(nameof(IconSize), defaultValue: double.NaN);
 
+        /// <summary>
+        /// Gets or sets the spacing between the icon and the text.
+        /// </summary>
         public double Spacing {
             get => GetValue(SpacingProperty);
             set => SetValue(SpacingProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the orientation in which the icon and the text will be layed out.
+        /// </summary>
         public Orientation Orientation {
             get => GetValue(OrientationProperty);
             set => SetValue(OrientationProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the text to display
+        /// </summary>
         public string? Text {
             get => GetValue(TextProperty);
             set => SetValue(TextProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets whether the text should appear on the left side instead of the right
+        /// </summary>
         public bool TextFirst {
             get => GetValue(TextFirstProperty);
             set => SetValue(TextFirstProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets whether the text should be selectable
+        /// </summary>
         public bool IsTextSelectable {
             get => GetValue(IsTextSelectableProperty);
             set => SetValue(IsTextSelectableProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the width and the height of the icon
+        /// </summary>
         public double IconSize {
             get => GetValue(IconSizeProperty);
             set => SetValue(IconSizeProperty, value);

--- a/Material.Icons.Avalonia/MaterialIconText.axaml.cs
+++ b/Material.Icons.Avalonia/MaterialIconText.axaml.cs
@@ -1,0 +1,55 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+
+namespace Material.Icons.Avalonia {
+    public class MaterialIconText : MaterialIcon {
+        public static readonly StyledProperty<double> SpacingProperty =
+            StackPanel.SpacingProperty.AddOwner<MaterialIconText>();
+
+        public static readonly StyledProperty<Orientation> OrientationProperty =
+            StackPanel.OrientationProperty.AddOwner<MaterialIconText>();
+
+        public static readonly StyledProperty<string?> TextProperty =
+            TextBlock.TextProperty.AddOwner<MaterialIconText>();
+
+        public static readonly StyledProperty<bool> TextFirstProperty =
+            AvaloniaProperty.Register<MaterialIconText, bool>(nameof(TextFirst));
+
+        public static readonly StyledProperty<bool> IsTextSelectableProperty =
+            AvaloniaProperty.Register<MaterialIconText, bool>(nameof(IsTextSelectable));
+
+        public static readonly StyledProperty<double> IconSizeProperty =
+            AvaloniaProperty.Register<MaterialIconText, double>(nameof(IconSize), defaultValue: double.NaN);
+
+        public double Spacing {
+            get => GetValue(SpacingProperty);
+            set => SetValue(SpacingProperty, value);
+        }
+
+        public Orientation Orientation {
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
+        }
+
+        public string? Text {
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public bool TextFirst {
+            get => GetValue(TextFirstProperty);
+            set => SetValue(TextFirstProperty, value);
+        }
+
+        public bool IsTextSelectable {
+            get => GetValue(IsTextSelectableProperty);
+            set => SetValue(IsTextSelectableProperty, value);
+        }
+
+        public double IconSize {
+            get => GetValue(IconSizeProperty);
+            set => SetValue(IconSizeProperty, value);
+        }
+    }
+}

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -12,19 +12,19 @@ namespace Material.Icons.Avalonia
         public MaterialIconTextExt(MaterialIconKind kind, double? size) : base(kind, size) { }
 
         [ConstructorArgument("spacing")]
-        public double? Spacing { get; set; } = 5;
+        public double? Spacing { get; set; }
 
         [ConstructorArgument("orientation")]
-        public Orientation? Orientation { get; set; } = global::Avalonia.Layout.Orientation.Horizontal;
+        public Orientation? Orientation { get; set; }
 
         [ConstructorArgument("text")]
         public string? Text { get; set; }
 
         [ConstructorArgument("textFirst")]
-        public bool? TextFirst { get; set; } = false;
+        public bool? TextFirst { get; set; }
 
         [ConstructorArgument("isTextSelectable")]
-        public bool? IsTextSelectable { get; set; } = false;
+        public bool? IsTextSelectable { get; set; }
         
         public override object ProvideValue(IServiceProvider serviceProvider) {
             if (string.IsNullOrWhiteSpace(Text)) return (Control)base.ProvideValue(serviceProvider);

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -12,47 +12,34 @@ namespace Material.Icons.Avalonia
         public MaterialIconTextExt(MaterialIconKind kind, double? size) : base(kind, size) { }
 
         [ConstructorArgument("spacing")]
-        public double Spacing { get; set; } = 5;
+        public double? Spacing { get; set; } = 5;
 
         [ConstructorArgument("orientation")]
-        public Orientation Orientation { get; set; } = Orientation.Horizontal;
+        public Orientation? Orientation { get; set; } = global::Avalonia.Layout.Orientation.Horizontal;
 
         [ConstructorArgument("text")]
         public string? Text { get; set; }
 
         [ConstructorArgument("textFirst")]
-        public bool TextFirst { get; set; } = false;
+        public bool? TextFirst { get; set; } = false;
 
         [ConstructorArgument("isTextSelectable")]
-        public bool IsTextSelectable { get; set; } = false;
+        public bool? IsTextSelectable { get; set; } = false;
         
         public override object ProvideValue(IServiceProvider serviceProvider) {
-            var icon = (Control)base.ProvideValue(serviceProvider);
-
-            if (string.IsNullOrWhiteSpace(Text)) return icon;
-
-            var textBlock = IsTextSelectable ?
-                new SelectableTextBlock {
-                    Text = Text,
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    VerticalAlignment = VerticalAlignment.Center,
-                }
-                : new TextBlock {
-                    Text = Text,
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    VerticalAlignment = VerticalAlignment.Center,
-                };
-
-            if (Size.HasValue) textBlock.FontSize = Size.Value;
-
-            return new StackPanel {
-                Orientation = Orientation,
-                Spacing = Spacing,
-                Children = {
-                    TextFirst ? textBlock : icon,
-                    TextFirst ? icon : textBlock
-                }
-            };
+            if (string.IsNullOrWhiteSpace(Text)) return (Control)base.ProvideValue(serviceProvider);
+            var result = new MaterialIconText();
+            if (Spacing.HasValue) result.Spacing = Spacing.Value;
+            if (Orientation.HasValue) result.Orientation = Orientation.Value;
+            if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
+            if (IsTextSelectable.HasValue) result.IsTextSelectable = IsTextSelectable.Value;
+            if (Size.HasValue) {
+                result.IconSize = Size.Value;
+                result.FontSize = Size.Value;
+            }
+            result.Kind = Kind;
+            result.Text = Text;
+            return result;
         }
     }
 }

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -27,7 +27,8 @@ namespace Material.Icons.Avalonia
         public bool? IsTextSelectable { get; set; }
         
         public override object ProvideValue(IServiceProvider serviceProvider) {
-            if (string.IsNullOrWhiteSpace(Text)) return (Control)base.ProvideValue(serviceProvider);
+            if (string.IsNullOrWhiteSpace(Text))
+                return base.ProvideValue(serviceProvider);
             var result = new MaterialIconText();
             if (Spacing.HasValue) result.Spacing = Spacing.Value;
             if (Orientation.HasValue) result.Orientation = Orientation.Value;

--- a/Material.Icons.WPF/MaterialIconText.cs
+++ b/Material.Icons.WPF/MaterialIconText.cs
@@ -22,26 +22,41 @@ namespace Material.Icons.WPF {
         public static readonly DependencyProperty IconSizeProperty = DependencyProperty.Register(
             nameof(IconSize), typeof(double), typeof(MaterialIconText), new PropertyMetadata(double.NaN));
 
+        /// <summary>
+        /// Gets or sets the spacing between the icon and the text
+        /// </summary>
         public double Spacing {
             get => (double)GetValue(SpacingProperty);
             set => SetValue(SpacingProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the orientation in which the icon and the text will be layed out.
+        /// </summary>
         public Orientation Orientation {
             get => (Orientation)GetValue(OrientationProperty);
             set => SetValue(OrientationProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the text to display
+        /// </summary>
         public string? Text {
             get => (string?)GetValue(TextProperty);
             set => SetValue(TextProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets whether the text should appear on the left side instead of the right
+        /// </summary>
         public bool TextFirst {
             get => (bool)GetValue(TextFirstProperty);
             set => SetValue(TextFirstProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the width and the height of the icon
+        /// </summary>
         public double IconSize {
             get => (double)GetValue(IconSizeProperty);
             set => SetValue(IconSizeProperty, value);

--- a/Material.Icons.WPF/MaterialIconText.cs
+++ b/Material.Icons.WPF/MaterialIconText.cs
@@ -10,11 +10,11 @@ namespace Material.Icons.WPF {
         public static readonly DependencyProperty SpacingProperty = DependencyProperty.Register(
             nameof(Spacing), typeof(double), typeof(MaterialIconText), new PropertyMetadata(default(double)));
 
-        public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
-            nameof(Orientation), typeof(Orientation), typeof(MaterialIconText), new PropertyMetadata(default(Orientation)));
+        public static readonly DependencyProperty OrientationProperty =
+            StackPanel.OrientationProperty.AddOwner(typeof(MaterialIconText));
 
-        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
-            nameof(Text), typeof(string), typeof(MaterialIconText), new PropertyMetadata(default(string?)));
+        public static readonly DependencyProperty TextProperty =
+                TextBlock.TextProperty.AddOwner(typeof(MaterialIconText));
 
         public static readonly DependencyProperty TextFirstProperty = DependencyProperty.Register(
             nameof(TextFirst), typeof(bool), typeof(MaterialIconText), new PropertyMetadata(default(bool)));

--- a/Material.Icons.WPF/MaterialIconText.cs
+++ b/Material.Icons.WPF/MaterialIconText.cs
@@ -2,7 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 
 namespace Material.Icons.WPF {
-    internal sealed class MaterialIconText : MaterialIcon {
+    public class MaterialIconText : MaterialIcon {
         static MaterialIconText() {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(MaterialIconText), new FrameworkPropertyMetadata(typeof(MaterialIconText)));
         }

--- a/Material.Icons.WPF/MaterialIconText.cs
+++ b/Material.Icons.WPF/MaterialIconText.cs
@@ -1,0 +1,50 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Material.Icons.WPF {
+    internal sealed class MaterialIconText : MaterialIcon {
+        static MaterialIconText() {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(MaterialIconText), new FrameworkPropertyMetadata(typeof(MaterialIconText)));
+        }
+
+        public static readonly DependencyProperty SpacingProperty = DependencyProperty.Register(
+            nameof(Spacing), typeof(double), typeof(MaterialIconText), new PropertyMetadata(default(double)));
+
+        public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
+            nameof(Orientation), typeof(Orientation), typeof(MaterialIconText), new PropertyMetadata(default(Orientation)));
+
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+            nameof(Text), typeof(string), typeof(MaterialIconText), new PropertyMetadata(default(string?)));
+
+        public static readonly DependencyProperty TextFirstProperty = DependencyProperty.Register(
+            nameof(TextFirst), typeof(bool), typeof(MaterialIconText), new PropertyMetadata(default(bool)));
+
+        public static readonly DependencyProperty IconSizeProperty = DependencyProperty.Register(
+            nameof(IconSize), typeof(double), typeof(MaterialIconText), new PropertyMetadata(double.NaN));
+
+        public double Spacing {
+            get => (double)GetValue(SpacingProperty);
+            set => SetValue(SpacingProperty, value);
+        }
+
+        public Orientation Orientation {
+            get => (Orientation)GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
+        }
+
+        public string? Text {
+            get => (string?)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public bool TextFirst {
+            get => (bool)GetValue(TextFirstProperty);
+            set => SetValue(TextFirstProperty, value);
+        }
+
+        public double IconSize {
+            get => (double)GetValue(IconSizeProperty);
+            set => SetValue(IconSizeProperty, value);
+        }
+    }
+}

--- a/Material.Icons.WPF/MaterialIconTextExt.cs
+++ b/Material.Icons.WPF/MaterialIconTextExt.cs
@@ -13,52 +13,34 @@ namespace Material.Icons.WPF
         public MaterialIconTextExt(MaterialIconKind kind, double size) : base(kind, size) { }
 
         [ConstructorArgument("spacing")]
-        public double Spacing { get; set; } = 5;
+        public double? Spacing { get; set; }
 
         [ConstructorArgument("orientation")]
-        public Orientation Orientation { get; set; } = Orientation.Horizontal;
+        public Orientation? Orientation { get; set; }
 
         [ConstructorArgument("text")]
         public string? Text { get; set; }
 
         [ConstructorArgument("textFirst")]
-        public bool TextFirst { get; set; } = false;
+        public bool? TextFirst { get; set; }
 
         public override object ProvideValue(IServiceProvider serviceProvider) {
-            var icon = (Control)base.ProvideValue(serviceProvider);
-            
             if (string.IsNullOrWhiteSpace(Text))
-                return icon;
-            
-            var textBlock = new TextBlock {
-                Text = Text,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
+                return base.ProvideValue(serviceProvider);
 
-            if (Size.HasValue)
-                textBlock.FontSize = Size.Value;
-
-            if (Spacing > 0) {
-                if (TextFirst) {
-                    textBlock.Margin = Orientation == Orientation.Horizontal 
-                        ? new Thickness(0, 0, Spacing, 0) 
-                        : new Thickness(0, 0, 0, Spacing);
-                }
-                else {
-                    textBlock.Margin = Orientation == Orientation.Horizontal 
-                        ? new Thickness(Spacing, 0, 0, 0) 
-                        : new Thickness(0, Spacing, 0, 0);
-                }
+            var result = new MaterialIconText();
+            if (Spacing.HasValue)
+                result.Spacing = Spacing.Value;
+            if (Orientation.HasValue)
+                result.Orientation = Orientation.Value;
+            if (TextFirst.HasValue)
+                result.TextFirst = TextFirst.Value;
+            if (Size.HasValue) {
+                result.IconSize = Size.Value;
+                result.FontSize = Size.Value;
             }
-
-            return new StackPanel {
-                Orientation = Orientation,
-                Children = {
-                    TextFirst ? textBlock : icon,
-                    TextFirst ? icon : textBlock
-                }
-            };
+            result.Text = Text;
+            return result;
         }
     }
 }

--- a/Material.Icons.WPF/SpacingAsMarginConverter.cs
+++ b/Material.Icons.WPF/SpacingAsMarginConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Material.Icons.WPF {
+    internal sealed class SpacingAsMarginConverter : IMultiValueConverter {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            var spacing = (double)values[0];
+            var orientation = (Orientation)values[1];
+            return orientation == Orientation.Horizontal
+                ? new Thickness(spacing, 0, 0, 0)
+                : new Thickness(0, spacing, 0, 0);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Material.Icons.WPF/Themes/Generic.xaml
+++ b/Material.Icons.WPF/Themes/Generic.xaml
@@ -22,4 +22,57 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style TargetType="{x:Type local:MaterialIconText}">
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="FlowDirection" Value="LeftToRight" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:MaterialIconText}">
+                    <StackPanel Orientation="{TemplateBinding Orientation}">
+                        <local:MaterialIcon Kind="{TemplateBinding Kind}"
+                                            Width="{TemplateBinding IconSize}"
+                                            Height="{TemplateBinding IconSize}"/>
+                        <TextBlock Text="{TemplateBinding Text}">
+                            <TextBlock.Margin>
+                                <MultiBinding>
+                                    <MultiBinding.Converter>
+                                        <local:SpacingAsMarginConverter/>
+                                    </MultiBinding.Converter>
+                                    <TemplateBinding Property="Spacing"/>
+                                    <TemplateBinding Property="Orientation"/>
+                                </MultiBinding>
+                            </TextBlock.Margin>
+                        </TextBlock>
+                    </StackPanel>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{TemplateBinding TextFirst}" Value="True">
+              <Setter Property="Spacing" Value="5"/>
+              <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type local:MaterialIconText}">
+                            <StackPanel Orientation="{TemplateBinding Orientation}">
+                                <TextBlock Text="{TemplateBinding Text}"/>
+                                <local:MaterialIcon Kind="{TemplateBinding Kind}"
+                                                    Width="{TemplateBinding IconSize}"
+                                                    Height="{TemplateBinding IconSize}">
+                                    <local:MaterialIcon.Margin>
+                                        <MultiBinding>
+                                            <MultiBinding.Converter>
+                                                <local:SpacingAsMarginConverter/>
+                                            </MultiBinding.Converter>
+                                            <TemplateBinding Property="Spacing"/>
+                                            <TemplateBinding Property="Orientation"/>
+                                        </MultiBinding>
+                                    </local:MaterialIcon.Margin>
+                                </local:MaterialIcon>
+                            </StackPanel>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/Material.Icons.WinUI3/MaterialIconText.cs
+++ b/Material.Icons.WinUI3/MaterialIconText.cs
@@ -5,13 +5,13 @@ namespace Material.Icons.WinUI3;
 
 public partial class MaterialIconText : MaterialIcon {
     public static readonly DependencyProperty SpacingProperty =
-        StackPanel.SpacingProperty.AddOwner(typeof(MaterialIconText));
+        DependencyProperty.Register(nameof(Spacing), typeof(double), typeof(MaterialIconText), new PropertyMetadata(double.NaN));
 
     public static readonly DependencyProperty OrientationProperty =
-        StackPanel.OrientationProperty.AddOwner(typeof(MaterialIconText));
+        DependencyProperty.Register(nameof(Orientation), typeof(Orientation), typeof(MaterialIconText), new PropertyMetadata(Orientation.Horizontal));
 
     public static readonly DependencyProperty TextProperty =
-        TextBlock.TextProperty.AddOwner(typeof(MaterialIconText));
+        DependencyProperty.Register(nameof(Text), typeof(string), typeof(MaterialIconText), new PropertyMetadata(null));
 
     public static readonly DependencyProperty TextFirstProperty =
         DependencyProperty.Register(nameof(TextFirst), typeof(bool), typeof(MaterialIconText), new PropertyMetadata(default(bool)));

--- a/Material.Icons.WinUI3/MaterialIconText.cs
+++ b/Material.Icons.WinUI3/MaterialIconText.cs
@@ -1,0 +1,61 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Material.Icons.WinUI3;
+
+public partial class MaterialIconText : MaterialIcon {
+    public static readonly DependencyProperty SpacingProperty =
+        StackPanel.SpacingProperty.AddOwner(typeof(MaterialIconText));
+
+    public static readonly DependencyProperty OrientationProperty =
+        StackPanel.OrientationProperty.AddOwner(typeof(MaterialIconText));
+
+    public static readonly DependencyProperty TextProperty =
+        TextBlock.TextProperty.AddOwner(typeof(MaterialIconText));
+
+    public static readonly DependencyProperty TextFirstProperty =
+        DependencyProperty.Register(nameof(TextFirst), typeof(bool), typeof(MaterialIconText), new PropertyMetadata(default(bool)));
+
+    public static readonly DependencyProperty IconSizeProperty =
+        DependencyProperty.Register(nameof(IconSize), typeof(double), typeof(MaterialIconText), new PropertyMetadata(double.NaN));
+
+    /// <summary>
+    /// Gets or sets the spacing between the icon and the text.
+    /// </summary>
+    public double Spacing {
+        get => (double)GetValue(SpacingProperty);
+        set => SetValue(SpacingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the orientation in which the icon and the text will be layed out.
+    /// </summary>
+    public Orientation Orientation {
+        get => (Orientation)GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the text to display
+    /// </summary>
+    public string? Text {
+        get => (string?)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the text should appear on the left side instead of the right
+    /// </summary>
+    public bool TextFirst {
+        get => (bool)GetValue(TextFirstProperty);
+        set => SetValue(TextFirstProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the width and the height of the icon
+    /// </summary>
+    public double IconSize {
+        get => (double)GetValue(IconSizeProperty);
+        set => SetValue(IconSizeProperty, value);
+    }
+}

--- a/Material.Icons.WinUI3/MaterialIconTextExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconTextExt.cs
@@ -9,34 +9,25 @@ public partial class MaterialIconTextExt : MaterialIconExt {
 
     public MaterialIconTextExt(MaterialIconKind kind, double size) : base(kind, size) { }
 
-    public double Spacing { get; set; } = 5;
+    public double? Spacing { get; set; }
 
-    public Orientation Orientation { get; set; } = Orientation.Horizontal;
+    public Orientation? Orientation { get; set; }
 
     public string? Text { get; set; }
 
-    public bool TextFirst { get; set; } = false;
+    public bool? TextFirst { get; set; }
 
     protected override object ProvideValue(IXamlServiceProvider serviceProvider) {
-        var icon = (Control)base.ProvideValue(serviceProvider);
-
-        if (string.IsNullOrWhiteSpace(Text)) return icon;
-
-        var textBlock = new TextBlock {
-            Text = Text,
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-
-        if (Size.HasValue) textBlock.FontSize = Size.Value;
-
-        return new StackPanel {
-            Orientation = Orientation,
-            Spacing = Spacing,
-            Children = {
-                TextFirst ? textBlock : icon,
-                TextFirst ? icon : textBlock
-            }
-        };
+        if (string.IsNullOrWhiteSpace(Text))
+            return base.ProvideValue(serviceProvider);
+        var result = new MaterialIconText();
+        if (Spacing.HasValue)
+            result.Spacing = Spacing.Value;
+        if (Orientation.HasValue)
+            result.Orientation = Orientation.Value;
+        if (TextFirst.HasValue)
+            result.TextFirst = TextFirst.Value;
+        result.Text = Text;
+        return result;
     }
 }

--- a/Material.Icons.WinUI3/Themes/Generic.xaml
+++ b/Material.Icons.WinUI3/Themes/Generic.xaml
@@ -23,4 +23,23 @@
       </Setter.Value>
     </Setter>
   </Style>
+
+  <Style TargetType="local:MaterialIconText">
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="FlowDirection" Value="LeftToRight" />
+    <Setter Property="Spacing" Value="5" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="local:MaterialIconText">
+          <StackPanel Orientation="{TemplateBinding Orientation}"
+                      Spacing="{TemplateBinding Spacing}">
+            <local:MaterialIcon Kind="{TemplateBinding Kind}"
+                                Width="{TemplateBinding IconSize}"
+                                Height="{TemplateBinding IconSize}"/>
+            <TextBlock Text="{TemplateBinding Text}"/>
+          </StackPanel>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
 </ResourceDictionary>


### PR DESCRIPTION
In my application, I redefined the `MaterialIcon` theme, which allowed me to easily globally change the appearance of the icon and not specify the parameters every time on the spot.

However, with the new `MaterialIconTextExt` extension, I can't do this because it creates a layout in place, and I would have to specify the necessary `Spacing` every time.

This PR changes the behavior of the `MaterialIconTextExt` so that it returns a new `MaterialIconText` templated control that can be redefined in the same way as the `MaterialIcon` control.

Although it is worth noting that the implemented Template in the `MaterialIconText` control is not as optimal as the layout that was created in the extension before, and the parameters in the `MaterialIconTextExt` are complicated by nullability in order to leave the default values set in `MaterialIconText` `ControlTheme` in case they are not set in the extension parameters.

In case of rejection of this PR, I personally could just create my own version of the extension, while those who do not need to redefine the default values globally through the theme may lose performance and suffer a change in the public API.

Even so, I will offer this PR because it may still be useful to someone.