### PR TITLE
Add cache to icons

### DIFF
--- a/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml.cs
+++ b/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml.cs
@@ -1,7 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Diagnostics;
-using Avalonia.Input;
-using Avalonia.Markup.Xaml;
 
 namespace Material.Icons.Avalonia.Demo.Views {
     public partial class MainWindow : Window {

--- a/Material.Icons.Avalonia/MaterialIconKindToGeometryConverter.cs
+++ b/Material.Icons.Avalonia/MaterialIconKindToGeometryConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
@@ -7,8 +6,18 @@ using Avalonia.Media;
 
 namespace Material.Icons.Avalonia {
     public class MaterialIconKindToGeometryConverter : IValueConverter {
+
         public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) {
             if (value is MaterialIconKind kind) {
+                if (MaterialIconOptions.UseCache) {
+                    if (MaterialIconOptions.Cache.TryGetValue(kind, out var geometry)) {
+                        return geometry;
+                    }
+                    geometry = Geometry.Parse(MaterialIconDataProvider.GetData(kind));
+                    MaterialIconOptions.Cache.Add(kind, geometry);
+                    return geometry;
+                }
+
                 return Geometry.Parse(MaterialIconDataProvider.GetData(kind));
             }
 

--- a/Material.Icons/MaterialIconOptions.cs
+++ b/Material.Icons/MaterialIconOptions.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System;
+
+namespace Material.Icons;
+
+/// <summary>
+/// Global options for the Material Icons library.
+/// </summary>
+public static class MaterialIconOptions {
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the cache for the icon, if true the icon won't be parsed twice.
+    /// </summary>
+    public static bool UseCache { get; set; }
+
+    /// <summary>
+    /// Gets the cache singleton for the icons. The cache is used to store the parsed icons to avoid parsing them multiple times.
+    /// </summary>
+
+    private static readonly Lazy<Dictionary<MaterialIconKind, object>> CacheLazy = new(() => new Dictionary<MaterialIconKind, object>());
+
+    /// <summary>
+    /// Gets the cache for the icons. The cache is used to store the parsed icons to avoid parsing them multiple times.
+    /// </summary>
+    public static Dictionary<MaterialIconKind, object> Cache => CacheLazy.Value;
+
+    /// <summary>
+    /// Clears the cache for the icons.
+    /// </summary>
+    public static void ClearCache() {
+        if (CacheLazy.IsValueCreated) Cache.Clear();
+    }
+}


### PR DESCRIPTION
Implements a cache system used to store the parsed icons to avoid parsing them multiple times.

Configurable via: `MaterialIconOptions.UseCache`
Cache is assessable via: `MaterialIconOptions.Cache`
Cache can be clear via: `MaterialIconOptions.ClearCache()`

Type `$cache` into demo window calls a test:

```
Cache=False for 10    icons, results in 2734 ticks / 0ms, Memory: 880 bytes
Cache=True  for 10    icons, results in 33 ticks / 0ms, Memory: 88 bytes

Cache=False for 100   icons, results in 15684 ticks / 1ms, Memory: 8 800 bytes
Cache=True  for 100   icons, results in 31 ticks / 0ms, Memory: 88 bytes

Cache=False for 1000  icons, results in 63557 ticks / 6ms, Memory: 88 000 bytes
Cache=True  for 1000  icons, results in 52 ticks / 0ms, Memory: 88 bytes

Cache=False for 10000 icons, results in 554003 ticks / 55ms, Memory: 880 000 bytes
Cache=True  for 10000 icons, results in 1755 ticks / 0ms, Memory: 88 bytes

Cache=False for 50000 icons, results in 2406005 ticks / 240ms, Memory: 4 400 000 bytes
Cache=True  for 50000 icons, results in 12398 ticks / 1ms, Memory: 88 bytes
```

This is only implemented for Avalonia.