### PR TITLE
Implements IImage on MaterialIcon

### DIFF
--- a/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml
+++ b/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml
@@ -1,9 +1,9 @@
 <Window x:Class="Material.Icons.Avalonia.Demo.Views.MainWindow"
         xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
         xmlns:controls="clr-namespace:Material.Icons.Avalonia.Demo.Controls"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:icon="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:models="clr-namespace:Material.Icons.Avalonia.Demo.Models"
         xmlns:system="clr-namespace:System;assembly=System.Runtime.Extensions"
@@ -34,9 +34,9 @@
   <Design.DataContext>
     <vm:MainWindowViewModel />
   </Design.DataContext>
-  <Grid ColumnDefinitions="*, *, 100"
+  <Grid ColumnDefinitions="*, *, 100,Auto,Auto"
         RowDefinitions="*, Auto">
-    <ScrollViewer Grid.ColumnSpan="3"
+    <ScrollViewer Grid.ColumnSpan="5"
                   HorizontalScrollBarVisibility="Disabled"
                   VerticalScrollBarVisibility="Visible">
       <ItemsRepeater HorizontalAlignment="Center"
@@ -59,12 +59,12 @@
                              FontSize="10"
                              Text="{Binding Kind}" />
 
-                  <avalonia:MaterialIcon Width="32"
-                                         Height="32"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center"
-                                         Animation="{Binding $parent[Window].DataContext.Animation}"
-                                         Kind="{Binding Kind}" />
+                  <icon:MaterialIcon Width="32"
+                                     Height="32"
+                                     HorizontalAlignment="Center"
+                                     VerticalAlignment="Center"
+                                     Animation="{Binding $parent[Window].DataContext.Animation}"
+                                     Kind="{Binding Kind}" />
                 </DockPanel>
               </Border>
             </controls:SelectionWrapper>
@@ -85,6 +85,25 @@
     <ComboBox Grid.Row="1"
               Grid.Column="2"
               ItemsSource="{Binding Animations, Mode=OneTime}"
-              SelectedItem="{Binding Animation}"/>
+              SelectedItem="{Binding Animation}" />
+
+    <icon:MaterialIcon Name="RandomIcon"
+                       Grid.Row="1"
+                       Grid.Column="3"
+                       Margin="10,5"
+                       ToolTip.Tip="Random icon" />
+
+    <Image Name="RandomImage"
+           Grid.Row="1"
+           Grid.Column="4"
+           Width="16"
+           Height="16"
+           Margin="0,5,10,5"
+           ToolTip.Tip="Random icon image">
+      <icon:MaterialIcon Name="RandomImageIcon"
+                         Foreground="DeepPink"
+                         Kind="Heart" />
+    </Image>
+
   </Grid>
 </Window>

--- a/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml.cs
+++ b/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml.cs
@@ -1,12 +1,24 @@
+using System;
 using Avalonia.Controls;
-using Avalonia.Diagnostics;
-using Avalonia.Input;
-using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 
 namespace Material.Icons.Avalonia.Demo.Views {
     public partial class MainWindow : Window {
         public MainWindow() {
             InitializeComponent();
+
+            var values = Enum.GetValues<MaterialIconKind>();
+
+            DispatcherTimer.Run(() => {
+
+                RandomIcon.Kind = values[Random.Shared.Next(0, values.Length)];
+                RandomImageIcon.Kind = values[Random.Shared.Next(0, values.Length)];
+#if RELEASE
+                // Without this line, image will not be updated with the new icon
+                RandomImage.InvalidateVisual();
+#endif
+                return true;
+            }, TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/Material.Icons.Avalonia/MaterialIcon.axaml
+++ b/Material.Icons.Avalonia/MaterialIcon.axaml
@@ -48,7 +48,7 @@
                              Kind="DotsVertical" />
 
           <icon:MaterialIconExt Animation="PulseCcw"
-                                IconBrush="Gold"
+                                IconForeground="Gold"
                                 Kind="ProgressHelper" />
 
           <icon:MaterialIcon Animation="FadeOutIn"
@@ -79,17 +79,17 @@
           </Border>
 
           <Border>
-            <Image Source="{icon:MaterialIconTextExt Kind=AddAlarm, IconBrush=WhiteSmoke, Text='DEBUG, no effect!', IconSize=512}" />
+            <Image Source="{icon:MaterialIconTextExt Kind=AddAlarm, IconForeground=WhiteSmoke, Text='DEBUG, no effect!', IconSize=512}" />
           </Border>
 
           <Border>
-            <Image Source="{icon:MaterialIconExt Kind=ProgressHelper, IconBrush=Gold, Animation=PulseCcw}" />
+            <Image Source="{icon:MaterialIconExt Kind=ProgressHelper, IconForeground=Gold, Animation=PulseCcw}" />
           </Border>
 
           <Border>
             <Image Width="92"
                    Source="{icon:MaterialIconExt Kind=Heart,
-                                                 IconBrush=DeepPink}"
+                                                 IconForeground=DeepPink}"
                    Stretch="Fill" />
           </Border>
 

--- a/Material.Icons.Avalonia/MaterialIcon.axaml
+++ b/Material.Icons.Avalonia/MaterialIcon.axaml
@@ -20,6 +20,17 @@
           <Setter Property="CornerRadius" Value="10" />
           <Setter Property="BorderThickness" Value="2" />
         </Style>
+        <Style Selector=".Images Border">
+          <Setter Property="Margin" Value="10,0,10,10" />
+          <Setter Property="Padding" Value="10" />
+          <Setter Property="BorderBrush" Value="Gray" />
+          <Setter Property="CornerRadius" Value="10" />
+          <Setter Property="BorderThickness" Value="2" />
+        </Style>
+        <Style Selector=".Images Image">
+          <Setter Property="Width" Value="24" />
+          <Setter Property="Height" Value="24" />
+        </Style>
       </Border.Styles>
       <StackPanel Orientation="Vertical"
                   Spacing="10">
@@ -36,8 +47,9 @@
           <icon:MaterialIcon Animation="Pulse"
                              Kind="DotsVertical" />
 
-          <icon:MaterialIcon Animation="PulseCcw"
-                             Kind="ProgressHelper" />
+          <icon:MaterialIconExt Animation="PulseCcw"
+                                IconBrush="Gold"
+                                Kind="ProgressHelper" />
 
           <icon:MaterialIcon Animation="FadeOutIn"
                              Foreground="DeepPink"
@@ -47,31 +59,53 @@
                              Kind="Heart" />
         </WrapPanel>
 
+        <WrapPanel Classes="Images"
+                   Orientation="Horizontal">
+          <Border>
+            <Image>
+              <icon:MaterialIcon Kind="Image" />
+            </Image>
+          </Border>
+
+          <Border>
+            <Image Source="{icon:MaterialIconExt Kind=Image}" />
+          </Border>
+
+          <Border>
+            <Image>
+              <icon:MaterialIcon Foreground="WhiteSmoke"
+                                 Kind="AddAlarm" />
+            </Image>
+          </Border>
+
+          <Border>
+            <Image Source="{icon:MaterialIconTextExt Kind=AddAlarm, IconBrush=WhiteSmoke, Text='DEBUG, no effect!', IconSize=512}" />
+          </Border>
+
+          <Border>
+            <Image Source="{icon:MaterialIconExt Kind=ProgressHelper, IconBrush=Gold, Animation=PulseCcw}" />
+          </Border>
+
+          <Border>
+            <Image Width="92"
+                   Source="{icon:MaterialIconExt Kind=Heart,
+                                                 IconBrush=DeepPink}"
+                   Stretch="Fill" />
+          </Border>
+
+        </WrapPanel>
+
         <StackPanel Orientation="Horizontal"
                     Spacing="20">
-          <TextBlock>
-            <StackPanel Orientation="Horizontal"
-                        Spacing="5">
-              <icon:MaterialIcon Kind="Network" />
-              <TextBlock Text="127.0.0.1" />
-            </StackPanel>
-          </TextBlock>
+          <icon:MaterialIconText Kind="Network"
+                                 Text="127.0.0.1" />
 
-          <TextBlock FontSize="16">
-            <StackPanel Orientation="Horizontal"
-                        Spacing="5">
-              <icon:MaterialIcon Kind="Network" />
-              <TextBlock Text="127.0.0.1 (16px)" />
-            </StackPanel>
-          </TextBlock>
-
-          <TextBlock FontSize="24">
-            <StackPanel Orientation="Horizontal"
-                        Spacing="5">
-              <icon:MaterialIcon Kind="Network" />
-              <TextBlock Text="127.0.0.1 (24px)" />
-            </StackPanel>
-          </TextBlock>
+          <icon:MaterialIconText FontSize="16"
+                                 Kind="Network"
+                                 Text="127.0.0.1 (16px)" />
+          <icon:MaterialIconText FontSize="24"
+                                 Kind="Network"
+                                 Text="127.0.0.1 (24px)" />
         </StackPanel>
 
 
@@ -178,7 +212,7 @@
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}">
           <Viewbox Name="PART_IconViewbox">
-            <Path Data="{TemplateBinding Kind, Converter={StaticResource GeometryConverter}}"
+            <Path Data="{Binding Drawing.Geometry, RelativeSource={RelativeSource TemplatedParent}}"
                   Fill="{TemplateBinding Foreground}"
                   Stretch="Uniform" />
           </Viewbox>

--- a/Material.Icons.Avalonia/MaterialIcon.axaml.cs
+++ b/Material.Icons.Avalonia/MaterialIcon.axaml.cs
@@ -77,10 +77,10 @@ namespace Material.Icons.Avalonia {
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e) {
             base.OnPropertyChanged(e);
 
-            if (ReferenceEquals(e.Property, KindProperty)) {
+            if (e.Property == KindProperty) {
                 SetGeometry();
             }
-            else if (ReferenceEquals(e.Property, ForegroundProperty)) {
+            else if (e.Property == ForegroundProperty) {
                 Drawing.Brush = Foreground;
             }
         }

--- a/Material.Icons.Avalonia/MaterialIcon.axaml.cs
+++ b/Material.Icons.Avalonia/MaterialIcon.axaml.cs
@@ -1,8 +1,13 @@
 ﻿using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Media;
 
 namespace Material.Icons.Avalonia {
-    public class MaterialIcon : TemplatedControl {
+
+    public class MaterialIcon : TemplatedControl, IImage {
+        #region Properties
+
         public static readonly StyledProperty<MaterialIconKind> KindProperty
             = AvaloniaProperty.Register<MaterialIcon, MaterialIconKind>(nameof(Kind));
 
@@ -35,5 +40,95 @@ namespace Material.Icons.Avalonia {
             get => GetValue(AnimationProperty);
             set => SetValue(AnimationProperty, value);
         }
+
+        public static readonly DirectProperty<MaterialIcon, GeometryDrawing> DrawingProperty =
+            AvaloniaProperty.RegisterDirect<MaterialIcon, GeometryDrawing>(
+                nameof(Drawing),
+                o => o.Drawing);
+
+        /// <summary>
+        /// Gets the <see cref="GeometryDrawing"/> of the icon.
+        /// </summary>
+        public GeometryDrawing Drawing { get; } = new();
+
+        // Default size for Material Icons
+        private static readonly Rect DefaultIconBounds = new(0, 0, 24, 24);
+
+        #endregion
+
+        #region Constructor
+
+        public MaterialIcon() {
+            Drawing.Brush = Foreground;
+        }
+
+        #endregion
+
+        #region Overrides
+
+        /// <inheritdoc />
+        protected override void OnLoaded(RoutedEventArgs e) {
+            if (Drawing.Geometry is null)
+                SetGeometry();
+            base.OnLoaded(e);
+        }
+
+        /// <inheritdoc />
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e) {
+            base.OnPropertyChanged(e);
+
+            if (ReferenceEquals(e.Property, KindProperty)) {
+                SetGeometry();
+            }
+            else if (ReferenceEquals(e.Property, ForegroundProperty)) {
+                Drawing.Brush = Foreground;
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Sets the geometry for the drawing based on the specified material icon kind.
+        /// </summary>
+        /// <remarks>This method updates the <see cref="Drawing"/> Geometry property by parsing the
+        /// geometry data associated with the current <see cref="Kind"/> value.
+        /// </remarks>
+        private void SetGeometry() {
+            // TODO: Implement future cache here
+            Drawing.Geometry = Geometry.Parse(MaterialIconDataProvider.GetData(Kind));
+        }
+
+        #endregion
+
+        #region IImage Implementation
+
+        /// <inheritdoc/>
+        Size IImage.Size => DefaultIconBounds.Size;
+
+        /// <inheritdoc/>
+        void IImage.Draw(DrawingContext context, Rect sourceRect, Rect destRect) {
+            if (Drawing.Geometry is null)
+                SetGeometry();
+
+            var bounds = DefaultIconBounds;
+            var scale = Matrix.CreateScale(
+                destRect.Width / sourceRect.Width,
+                destRect.Height / sourceRect.Height
+            );
+            var translate = Matrix.CreateTranslation(
+                -sourceRect.X + destRect.X - bounds.X,
+                -sourceRect.Y + destRect.Y - bounds.Y
+            );
+
+            using (context.PushClip(destRect))
+            using (context.PushTransform(translate * scale)) {
+                Drawing.Draw(context);
+            }
+        }
+
+        #endregion
+
     }
 }

--- a/Material.Icons.Avalonia/MaterialIconExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconExt.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
 
 namespace Material.Icons.Avalonia {
     public class MaterialIconExt : MarkupExtension {
@@ -23,6 +24,9 @@ namespace Material.Icons.Avalonia {
         [ConstructorArgument("iconSize")]
         public double? IconSize { get; set; }
 
+        [ConstructorArgument("iconBrush")]
+        public IBrush? IconBrush { get; set; }
+
         [ConstructorArgument("animation")]
         public MaterialIconAnimation Animation { get; set; }
 
@@ -37,6 +41,10 @@ namespace Material.Icons.Avalonia {
 
             if (IconSize.HasValue) {
                 result.IconSize = IconSize.Value;
+            }
+
+            if (IconBrush is not null) {
+                result.Foreground = IconBrush;
             }
 
             if (!string.IsNullOrWhiteSpace(Classes)) {

--- a/Material.Icons.Avalonia/MaterialIconExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconExt.cs
@@ -24,8 +24,8 @@ namespace Material.Icons.Avalonia {
         [ConstructorArgument("iconSize")]
         public double? IconSize { get; set; }
 
-        [ConstructorArgument("iconBrush")]
-        public IBrush? IconBrush { get; set; }
+        [ConstructorArgument("iconForeground")]
+        public IBrush? IconForeground { get; set; }
 
         [ConstructorArgument("animation")]
         public MaterialIconAnimation Animation { get; set; }
@@ -43,8 +43,8 @@ namespace Material.Icons.Avalonia {
                 result.IconSize = IconSize.Value;
             }
 
-            if (IconBrush is not null) {
-                result.Foreground = IconBrush;
+            if (IconForeground is not null) {
+                result.Foreground = IconForeground;
             }
 
             if (!string.IsNullOrWhiteSpace(Classes)) {

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -46,7 +46,7 @@ namespace Material.Icons.Avalonia
             };
 
             if (IconSize.HasValue) result.IconSize = IconSize.Value;
-            if (IconBrush is not null) result.Foreground = IconBrush;
+            if (IconForeground is not null) result.Foreground = IconForeground;
 
             if (Spacing.HasValue) result.Spacing = Spacing.Value;
             if (Orientation.HasValue) result.Orientation = Orientation.Value;

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -39,20 +39,24 @@ namespace Material.Icons.Avalonia
             if (string.IsNullOrWhiteSpace(Text))
                 return base.ProvideValue(serviceProvider);
 
-            var result = new MaterialIconText();
+            var result = new MaterialIconText {
+                Kind = Kind,
+                Text = Text,
+                Animation = Animation
+            };
+
+            if (IconSize.HasValue) result.IconSize = IconSize.Value;
+            if (IconBrush is not null) result.Foreground = IconBrush;
+
             if (Spacing.HasValue) result.Spacing = Spacing.Value;
             if (Orientation.HasValue) result.Orientation = Orientation.Value;
             if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
             if (IsTextSelectable.HasValue) result.IsTextSelectable = IsTextSelectable.Value;
-            if (IconSize.HasValue) {
-                result.IconSize = IconSize.Value;
-            }
+
             if (!string.IsNullOrWhiteSpace(Classes)) {
                 result.Classes.AddRange(global::Avalonia.Controls.Classes.Parse(Classes!));
             }
-            result.Kind = Kind;
-            result.Text = Text;
-            result.Animation = Animation;
+
             return result;
         }
     }

--- a/Material.Icons.WPF/MaterialIconExt.cs
+++ b/Material.Icons.WPF/MaterialIconExt.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Markup;
+using System.Windows.Media;
 
 namespace Material.Icons.WPF {
     [MarkupExtensionReturnType(typeof(MaterialIcon))]
@@ -28,6 +29,9 @@ namespace Material.Icons.WPF {
         [ConstructorArgument("iconSize")]
         public double? IconSize { get; set; }
 
+        [ConstructorArgument("iconBrush")]
+        public Brush? IconBrush { get; set; }
+
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
             var result = new MaterialIcon
@@ -40,6 +44,11 @@ namespace Material.Icons.WPF {
             {
                 result.Height = IconSize.Value;
                 result.Width = IconSize.Value;
+            }
+
+            if (IconBrush is not null)
+            {
+                result.Foreground = IconBrush;
             }
 
             return result;

--- a/Material.Icons.WPF/MaterialIconExt.cs
+++ b/Material.Icons.WPF/MaterialIconExt.cs
@@ -29,8 +29,8 @@ namespace Material.Icons.WPF {
         [ConstructorArgument("iconSize")]
         public double? IconSize { get; set; }
 
-        [ConstructorArgument("iconBrush")]
-        public Brush? IconBrush { get; set; }
+        [ConstructorArgument("iconForeground")]
+        public Brush? IconForeground { get; set; }
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
@@ -46,9 +46,9 @@ namespace Material.Icons.WPF {
                 result.Width = IconSize.Value;
             }
 
-            if (IconBrush is not null)
+            if (IconForeground is not null)
             {
-                result.Foreground = IconBrush;
+                result.Foreground = IconForeground;
             }
 
             return result;

--- a/Material.Icons.WPF/MaterialIconTextExt.cs
+++ b/Material.Icons.WPF/MaterialIconTextExt.cs
@@ -45,7 +45,7 @@ namespace Material.Icons.WPF
                 result.IconSize = IconSize.Value;
                 result.FontSize = IconSize.Value;
             }
-            if (IconBrush is not null) result.Foreground = IconBrush;
+            if (IconForeground is not null) result.Foreground = IconForeground;
 
             if (Spacing.HasValue) result.Spacing = Spacing.Value;
             if (Orientation.HasValue) result.Orientation = Orientation.Value;

--- a/Material.Icons.WPF/MaterialIconTextExt.cs
+++ b/Material.Icons.WPF/MaterialIconTextExt.cs
@@ -35,20 +35,22 @@ namespace Material.Icons.WPF
             if (string.IsNullOrWhiteSpace(Text))
                 return base.ProvideValue(serviceProvider);
 
-            var result = new MaterialIconText();
-            if (Spacing.HasValue)
-                result.Spacing = Spacing.Value;
-            if (Orientation.HasValue)
-                result.Orientation = Orientation.Value;
-            if (TextFirst.HasValue)
-                result.TextFirst = TextFirst.Value;
+            var result = new MaterialIconText {
+                Kind = Kind,
+                Text = Text,
+                Animation = Animation
+            };
+
             if (IconSize.HasValue) {
                 result.IconSize = IconSize.Value;
                 result.FontSize = IconSize.Value;
             }
-            result.Kind = Kind;
-            result.Text = Text;
-            result.Animation = Animation;
+            if (IconBrush is not null) result.Foreground = IconBrush;
+
+            if (Spacing.HasValue) result.Spacing = Spacing.Value;
+            if (Orientation.HasValue) result.Orientation = Orientation.Value;
+            if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
+
             return result;
         }
     }

--- a/Material.Icons.WinUI3/MaterialIconExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconExt.cs
@@ -25,7 +25,7 @@ public partial class MaterialIconExt : MarkupExtension {
 
     public double? IconSize { get; set; }
 
-    public Brush? IconBrush { get; set; }
+    public Brush? IconForeground { get; set; }
 
     protected override object ProvideValue(IXamlServiceProvider serviceProvider) {
         var result = new MaterialIcon
@@ -39,8 +39,8 @@ public partial class MaterialIconExt : MarkupExtension {
             result.Width = IconSize.Value;
         }
 
-        if (IconBrush is not null) {
-            result.Foreground = IconBrush;
+        if (IconForeground is not null) {
+            result.Foreground = IconForeground;
         }
 
         return result;

--- a/Material.Icons.WinUI3/MaterialIconExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconExt.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
 
 namespace Material.Icons.WinUI3;
 
@@ -24,6 +25,8 @@ public partial class MaterialIconExt : MarkupExtension {
 
     public double? IconSize { get; set; }
 
+    public Brush? IconBrush { get; set; }
+
     protected override object ProvideValue(IXamlServiceProvider serviceProvider) {
         var result = new MaterialIcon
         {
@@ -34,6 +37,10 @@ public partial class MaterialIconExt : MarkupExtension {
         if (IconSize.HasValue) {
             result.Height = IconSize.Value;
             result.Width = IconSize.Value;
+        }
+
+        if (IconBrush is not null) {
+            result.Foreground = IconBrush;
         }
 
         return result;

--- a/Material.Icons.WinUI3/MaterialIconTextExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconTextExt.cs
@@ -38,7 +38,7 @@ public partial class MaterialIconTextExt : MaterialIconExt {
         };
 
         if (IconSize.HasValue) result.IconSize = IconSize.Value;
-        if (IconBrush is not null) result.Foreground = IconBrush;
+        if (IconForeground is not null) result.Foreground = IconForeground;
 
         if (Spacing.HasValue) result.Spacing = Spacing.Value;
         if (Orientation.HasValue) result.Orientation = Orientation.Value;

--- a/Material.Icons.WinUI3/MaterialIconTextExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconTextExt.cs
@@ -31,19 +31,19 @@ public partial class MaterialIconTextExt : MaterialIconExt {
         if (string.IsNullOrWhiteSpace(Text))
             return base.ProvideValue(serviceProvider);
 
-        var result = new MaterialIconText();
-        if (Spacing.HasValue)
-            result.Spacing = Spacing.Value;
-        if (Orientation.HasValue)
-            result.Orientation = Orientation.Value;
-        if (TextFirst.HasValue)
-            result.TextFirst = TextFirst.Value;
-        if (IconSize.HasValue) {
-            result.IconSize = IconSize.Value;
-        }
-        result.Kind = Kind;
-        result.Text = Text;
-        result.Animation = Animation;
+        var result = new MaterialIconText {
+            Kind = Kind,
+            Text = Text,
+            Animation = Animation
+        };
+
+        if (IconSize.HasValue) result.IconSize = IconSize.Value;
+        if (IconBrush is not null) result.Foreground = IconBrush;
+
+        if (Spacing.HasValue) result.Spacing = Spacing.Value;
+        if (Orientation.HasValue) result.Orientation = Orientation.Value;
+        if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
+
         return result;
     }
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ Or with a text via `MaterialIconTextExt`:
 <Button Content="{materialIcons:MaterialIconTextExt Kind=Play, Text=Play}" />
 ```
 
+The `MaterialIcon` implements `IImage` interface, to allow to use as an `Image` source:
+```xaml
+<!-- Verbose raw method -->
+<Image>
+    <materialIcons:MaterialIcon Kind="Abacus" />
+</Image>
+
+<!-- Short extension method -->
+<Image Source="{materialIcons:MaterialIconExt Kind=Abacus}" />
+```
+
+Note that when using `MaterialIcon` as an `Image` source, the `Width` and `Height` properties must be defined under `<Image>`, 
+any size definition on `MaterialIcon` have no impact. Also, animation are not supported in this use case.  
+
+
 ## Avalonia FuncUI (F#)
 #### Getting started
 1. Install [Material.Icons.Avalonia nuget package](https://www.nuget.org/packages/Material.Icons.Avalonia/):

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ The `MaterialIcon` implements `IImage` interface, to allow to use as an `Image` 
 ```xaml
 <!-- Verbose raw method -->
 <Image>
-    <materialIcons:MaterialIcon Kind="Abacus" />
+    <materialIcons:MaterialIcon Foreground="DeepPink" Kind="Abacus" />
 </Image>
 
 <!-- Short extension method -->
-<Image Source="{materialIcons:MaterialIconExt Kind=Abacus}" />
+<Image Source="{materialIcons:MaterialIconExt Kind=Abacus, IconForeground="DeepPink"}" />
 ```
 
 Note that when using `MaterialIcon` as an `Image` source, the `Width` and `Height` properties must be defined under `<Image>`, 


### PR DESCRIPTION
Closes #53

- **Only Avalonia implementation**
- Implemented IImage into `MaterialIcon`
- Add `Drawing` property to `MaterialIcon`, as so, user can get and use the Drawing and the drawn geometry for any use. This also mean the converter is unused and not required anymore, but I've kept it in any case. This was added mostly to avoid two parses and to handle parse as one instead having two ways (One for control and other for IImage).
- Add `IconBrush` property to `MaterialIconExt` classes to easy set icon Foreground, this will easy the Ext usage under `Image` tag
- Optimized for performance and simplicity
- Original usage unchanged.

## IImage Limitations:

- `FontSize`, `IconSize` have no impact.
- No foreground from parent, Image lacks foreground, using self-Foreground or user must set.
- No Animations support, user need to implement such at Image level
- If the `Kind` is changed under a `<Image>` after loaded it won't update unless user call `Image.InvalidateVisual()`.

## Considerations

- If we create a new class `MaterialIconImage` we can probably solve the dynamic `Kind` change (Had to test), and probably better performance in such Image use since we are not creating a control, however we would need to also create extension to ease the use on the `<Image Source="">`, more code to cover.
- Consider the `IconBrush` property naming, could be:
  - `IconBrush`
  - `IconColor`
  - `IconForeground`
  -- Which sounds better? Maybe `IconForeground` for consistency?

## Examples:

```xml
<WrapPanel Classes="Images"
           Orientation="Horizontal">
  <Border>
    <Image>
      <icon:MaterialIcon Kind="Image" />
    </Image>
  </Border>

  <Border>
    <Image Source="{icon:MaterialIconExt Kind=Image}" />
  </Border>

  <Border>
    <Image>
      <icon:MaterialIcon Foreground="WhiteSmoke" Kind="AddAlarm" />
    </Image>
  </Border>

  <Border>
    <Image Source="{icon:MaterialIconTextExt Kind=AddAlarm, IconBrush=WhiteSmoke, Text='DEBUG, no effect!', IconSize=512}" />
  </Border>

  <Border>
    <Image Source="{icon:MaterialIconExt Kind=ProgressHelper, IconBrush=Gold, Animation=PulseCcw}" />
  </Border>

  <Border>
    <Image Width="92"
           Source="{icon:MaterialIconExt Kind=Heart, IconBrush=DeepPink}"
           Stretch="Fill" />
  </Border>

</WrapPanel>
```

![image](https://github.com/user-attachments/assets/b225d7c8-ec92-4b79-9a27-0b606d14abf5)
