### PR TITLE
Rework MaterialIconText

### DIFF
--- a/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
+++ b/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
@@ -15,12 +15,12 @@
         <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.3" />
+        <PackageReference Include="Avalonia" Version="11.3.0" />
         <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.2.3" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.2.3" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.0" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Material.Icons.Avalonia\Material.Icons.Avalonia.csproj" />

--- a/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
+++ b/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0" />
+    <PackageReference Include="Avalonia" Version="11.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Material.Icons.Avalonia/MaterialIconExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconExt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 
@@ -30,6 +31,12 @@ namespace Material.Icons.Avalonia {
         [ConstructorArgument("animation")]
         public MaterialIconAnimation Animation { get; set; }
 
+        [ConstructorArgument("verticalAlignment")]
+        public VerticalAlignment? VerticalAlignment { get; set; }
+
+        [ConstructorArgument("horizontalAlignment")]
+        public HorizontalAlignment? HorizontalAlignment { get; set; }
+
         [ConstructorArgument("classes")]
         public string? Classes { get; set; }
 
@@ -39,13 +46,11 @@ namespace Material.Icons.Avalonia {
                 Animation = Animation
             };
 
-            if (IconSize.HasValue) {
-                result.IconSize = IconSize.Value;
-            }
+            if (IconSize is not null) result.IconSize = IconSize.Value;
+            if (IconForeground is not null) result.Foreground = IconForeground;
 
-            if (IconForeground is not null) {
-                result.Foreground = IconForeground;
-            }
+            if (VerticalAlignment is not null) result.VerticalAlignment = VerticalAlignment.Value;
+            if (HorizontalAlignment is not null) result.HorizontalAlignment = HorizontalAlignment.Value;
 
             if (!string.IsNullOrWhiteSpace(Classes)) {
                 result.Classes.AddRange(global::Avalonia.Controls.Classes.Parse(Classes!));

--- a/Material.Icons.Avalonia/MaterialIconText.axaml
+++ b/Material.Icons.Avalonia/MaterialIconText.axaml
@@ -7,30 +7,85 @@
                 Margin="10"
                 Spacing="10">
       <StackPanel.Styles>
+        <Style Selector="avalonia|MaterialIconText.BoldPink">
+          <Setter Property="Foreground" Value="DeepPink" />
+          <Setter Property="FontSize" Value="18" />
+          <Setter Property="FontWeight" Value="Bold" />
+        </Style>
+        <Style Selector="TextBlock.h1, SelectableTextBlock.h1">
+          <Setter Property="Padding" Value="10" />
+          <Setter Property="FontSize" Value="32" />
+          <Setter Property="FontWeight" Value="Bold" />
+        </Style>
+        <Style Selector="avalonia|MaterialIcon.h1">
+          <Setter Property="FontSize" Value="32" />
+        </Style>
+        <Style Selector="StackPanel.iconPlacements avalonia|MaterialIconText">
+          <Setter Property="Kind" Value="Mountain" />
+          <Setter Property="Padding" Value="6" />
+          <Setter Property="BorderBrush" Value="LightGray" />
+          <Setter Property="BorderThickness" Value="1" />
+          <Setter Property="CornerRadius" Value="5" />
+        </Style>
         <Style Selector="Button:pressed">
           <Setter Property="Opacity" Value="0.5" />
           <Setter Property="FontSize" Value="28" />
         </Style>
       </StackPanel.Styles>
-      <avalonia:MaterialIconText Text="Icon with text!" />
-      <avalonia:MaterialIconText Kind="Mountain"
-                                 Text="with text first"
-                                 TextFirst="True" />
-      <avalonia:MaterialIconText IsTextSelectable="True"
-                                 Kind="Mountain"
-                                 Text="or selectable" />
-      <avalonia:MaterialIconText IsTextSelectable="True"
-                                 Kind="Mountain"
-                                 Text="or both"
-                                 TextFirst="True" />
+
+      <DockPanel>
+        <avalonia:MaterialIconText Classes="h1"
+                                   DockPanel.Dock="Left"
+                                   Kind="Information"
+                                   Text="MaterialIconText" />
+        <avalonia:MaterialIconText HorizontalAlignment="Right"
+                                   Classes="BoldPink"
+                                   DockPanel.Dock="Right"
+                                   IconPlacement="Right"
+                                   Kind="Heart"
+                                   Spacing="10"
+                                   Text="Styled text" />
+      </DockPanel>
+
+      <StackPanel Orientation="Horizontal"
+                  Spacing="20">
+        <avalonia:MaterialIconText Text="Icon with text!" />
+        <avalonia:MaterialIconText IsTextSelectable="True"
+                                   Kind="Mountain"
+                                   Text="or selectable" />
+
+        <avalonia:MaterialIconText FontSize="18"
+                                   FontWeight="Bold"
+                                   IconSize="28"
+                                   Kind="FormatBold"
+                                   Text="Bold" />
+      </StackPanel>
+
+
+      <StackPanel Classes="iconPlacements"
+                  Orientation="Horizontal"
+                  Spacing="20">
+        <avalonia:MaterialIconText IconPlacement="Left"
+                                   Text="Left placement" />
+
+        <avalonia:MaterialIconText IconPlacement="Top"
+                                   Text="Top placement" />
+
+        <avalonia:MaterialIconText IconPlacement="Right"
+                                   Text="Right placement" />
+
+        <avalonia:MaterialIconText IconPlacement="Bottom"
+                                   Text="Bottom placement" />
+      </StackPanel>
+
       <avalonia:MaterialIconText Padding="5"
                                  Animation="Spin"
                                  BorderBrush="Gray"
                                  BorderThickness="1"
                                  CornerRadius="10"
                                  FontSize="28"
-                                 IconSize="16"
                                  Kind="Refresh"
+                                 Spacing="10"
                                  Text="Spinning Icon!" />
       <Button Content="{avalonia:MaterialIconTextExt Kind=Mountain, Text='and via extension, fixed icon size', IconSize=16}" />
       <Button Content="{avalonia:MaterialIconTextExt Kind=Refresh, Animation=Spin, Text='and via extension'}" />
@@ -45,47 +100,48 @@
 
   <ControlTheme x:Key="{x:Type avalonia:MaterialIconText}"
                 TargetType="avalonia:MaterialIconText">
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="Spacing" Value="5" />
-    <Setter Property="Orientation" Value="Horizontal" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Padding="{TemplateBinding Padding}"
                 Background="{TemplateBinding Background}"
+                BackgroundSizing="{TemplateBinding BackgroundSizing}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}">
-          <StackPanel Orientation="{TemplateBinding Orientation}"
-                      Spacing="{TemplateBinding Spacing}">
-            <avalonia:MaterialIcon Name="PART_LeftIcon"
-                                   Animation="{TemplateBinding Animation}"
-                                   IconSize="{TemplateBinding IconSize}"
-                                   Kind="{TemplateBinding Kind}" />
-            <TextBlock HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       FontSize="{TemplateBinding FontSize}"
-                       Text="{TemplateBinding Text}" />
-            <SelectableTextBlock HorizontalAlignment="Center"
-                                 VerticalAlignment="Center"
-                                 FontSize="{TemplateBinding FontSize}"
-                                 IsVisible="False"
-                                 Text="{TemplateBinding Text}" />
-            <avalonia:MaterialIcon Name="PART_RightIcon"
-                                   Animation="{TemplateBinding Animation}"
-                                   IconSize="{TemplateBinding IconSize}"
+
+          <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                ColumnDefinitions="Auto"
+                RowDefinitions="Auto">
+            <DockPanel HorizontalSpacing="{TemplateBinding Spacing}"
+                       LastChildFill="False"
+                       VerticalSpacing="{TemplateBinding Spacing}">
+              <avalonia:MaterialIcon Name="PART_Icon"
+                                     HorizontalAlignment="Center"
+                                     VerticalAlignment="Center"
+                                     Animation="{TemplateBinding Animation}"
+                                     DockPanel.Dock="{TemplateBinding IconPlacement}"
+                                     IconSize="{TemplateBinding IconSize}"
+                                     Kind="{TemplateBinding Kind}" />
+
+              <TextBlock Name="PART_TextBlock"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         FontSize="{TemplateBinding FontSize}"
+                         Text="{TemplateBinding Text}" />
+              <SelectableTextBlock Name="PART_SelectableTextBlock"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontSize="{TemplateBinding FontSize}"
                                    IsVisible="False"
-                                   Kind="{TemplateBinding Kind}" />
-          </StackPanel>
+                                   Text="{TemplateBinding Text}" />
+            </DockPanel>
+          </Grid>
         </Border>
       </ControlTemplate>
     </Setter>
-    <Style Selector="^[TextFirst=True]">
-      <Style Selector="^ /template/ avalonia|MaterialIcon#LeftIcon">
-        <Setter Property="IsVisible" Value="False" />
-      </Style>
-      <Style Selector="^ /template/ avalonia|MaterialIcon#RightIcon">
-        <Setter Property="IsVisible" Value="True" />
-      </Style>
-    </Style>
     <Style Selector="^[IsTextSelectable=True]">
       <Style Selector="^ /template/ TextBlock">
         <Setter Property="IsVisible" Value="False" />

--- a/Material.Icons.Avalonia/MaterialIconText.axaml.cs
+++ b/Material.Icons.Avalonia/MaterialIconText.axaml.cs
@@ -5,9 +5,13 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 
 namespace Material.Icons.Avalonia {
-    [TemplatePart("PART_LeftIcon", typeof(MaterialIcon))]
-    [TemplatePart("PART_RightIcon", typeof(MaterialIcon))]
+    [TemplatePart("PART_Icon", typeof(MaterialIcon))]
+    [TemplatePart("PART_TextBlock", typeof(TextBlock))]
+    [TemplatePart("PART_SelectableTextBlock", typeof(SelectableTextBlock))]
     public class MaterialIconText : MaterialIcon {
+        public static readonly StyledProperty<Dock> IconPlacementProperty =
+            DockPanel.DockProperty.AddOwner<MaterialIconText>();
+
         public static readonly StyledProperty<double> SpacingProperty =
             StackPanel.SpacingProperty.AddOwner<MaterialIconText>();
 
@@ -17,13 +21,30 @@ namespace Material.Icons.Avalonia {
         public static readonly StyledProperty<string?> TextProperty =
             TextBlock.TextProperty.AddOwner<MaterialIconText>();
 
-        public static readonly StyledProperty<bool> TextFirstProperty =
-            AvaloniaProperty.Register<MaterialIconText, bool>(nameof(TextFirst));
-
         public static readonly StyledProperty<bool> IsTextSelectableProperty =
             AvaloniaProperty.Register<MaterialIconText, bool>(nameof(IsTextSelectable));
 
-       /// <summary>
+        /// <summary>
+        /// Defines the <see cref="HorizontalContentAlignment"/> property.
+        /// </summary>
+        public static readonly StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
+            ContentControl.HorizontalContentAlignmentProperty.AddOwner<MaterialIconText>();
+
+        /// <summary>
+        /// Defines the <see cref="VerticalContentAlignment"/> property.
+        /// </summary>
+        public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
+            ContentControl.VerticalContentAlignmentProperty.AddOwner<MaterialIconText>();
+
+        /// <summary>
+        /// Gets or sets the icon placement relative to the text.
+        /// </summary>
+        public Dock IconPlacement {
+            get => GetValue(IconPlacementProperty);
+            set => SetValue(IconPlacementProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets the spacing between the icon and the text.
         /// </summary>
         public double Spacing {
@@ -48,14 +69,6 @@ namespace Material.Icons.Avalonia {
         }
 
         /// <summary>
-        /// Gets or sets whether the text should appear on the left side instead of the right
-        /// </summary>
-        public bool TextFirst {
-            get => GetValue(TextFirstProperty);
-            set => SetValue(TextFirstProperty, value);
-        }
-
-        /// <summary>
         /// Gets or sets whether the text should be selectable
         /// </summary>
         public bool IsTextSelectable {
@@ -63,15 +76,37 @@ namespace Material.Icons.Avalonia {
             set => SetValue(IsTextSelectableProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the horizontal alignment of the content within the control.
+        /// </summary>
+        public HorizontalAlignment HorizontalContentAlignment {
+            get => GetValue(HorizontalContentAlignmentProperty);
+            set => SetValue(HorizontalContentAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the vertical alignment of the content within the control.
+        /// </summary>
+        public VerticalAlignment VerticalContentAlignment {
+            get => GetValue(VerticalContentAlignmentProperty);
+            set => SetValue(VerticalContentAlignmentProperty, value);
+        }
+
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e) {
             base.OnApplyTemplate(e);
 
-            // Redirect classses to the left and right icons
-            var leftIcon = e.NameScope.Get<MaterialIcon>("PART_LeftIcon");
-            var rightIcon = e.NameScope.Get<MaterialIcon>("PART_RightIcon");
+            var classes = Classes;
+            if (classes.Count > 0) {
 
-            leftIcon.Classes.AddRange(Classes);
-            rightIcon.Classes.AddRange(Classes);
+                // Redirect classses to the template parts
+                var icon = e.NameScope.Get<MaterialIcon>("PART_Icon");
+                var textBlock = e.NameScope.Get<TextBlock>("PART_TextBlock");
+                var selectableTextBlock = e.NameScope.Get<SelectableTextBlock>("PART_SelectableTextBlock");
+
+                icon.Classes.AddRange(classes);
+                textBlock.Classes.AddRange(classes);
+                selectableTextBlock.Classes.AddRange(classes);
+            }
         }
     }
 }

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 
@@ -20,20 +21,29 @@ namespace Material.Icons.Avalonia
             Text = text;
         }
 
+        public MaterialIconTextExt(MaterialIconKind kind, double? iconSize, Dock? iconPlacement, string? text = null, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null)
+            : base(kind, iconSize, animation, classes) {
+            IconPlacement = iconPlacement;
+            Text = text;
+        }
+
+        [ConstructorArgument("iconPlacement")]
+        public Dock? IconPlacement { get; set; }
+
         [ConstructorArgument("spacing")]
         public double? Spacing { get; set; }
-
-        [ConstructorArgument("orientation")]
-        public Orientation? Orientation { get; set; }
 
         [ConstructorArgument("text")]
         public string? Text { get; set; }
 
-        [ConstructorArgument("textFirst")]
-        public bool? TextFirst { get; set; }
-
         [ConstructorArgument("isTextSelectable")]
         public bool? IsTextSelectable { get; set; }
+
+        [ConstructorArgument("verticalContentAlignment")]
+        public VerticalAlignment? VerticalContentAlignment { get; set; }
+
+        [ConstructorArgument("horizontalContentAlignment")]
+        public HorizontalAlignment? HorizontalContentAlignment { get; set; }
 
         public override object ProvideValue(IServiceProvider serviceProvider) {
             if (string.IsNullOrWhiteSpace(Text))
@@ -45,13 +55,17 @@ namespace Material.Icons.Avalonia
                 Animation = Animation
             };
 
-            if (IconSize.HasValue) result.IconSize = IconSize.Value;
+            if (IconSize is not null) result.IconSize = IconSize.Value;
             if (IconForeground is not null) result.Foreground = IconForeground;
+            if (IconPlacement is not null) result.IconPlacement = IconPlacement.Value;
 
-            if (Spacing.HasValue) result.Spacing = Spacing.Value;
-            if (Orientation.HasValue) result.Orientation = Orientation.Value;
-            if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
-            if (IsTextSelectable.HasValue) result.IsTextSelectable = IsTextSelectable.Value;
+            if (Spacing is not null) result.Spacing = Spacing.Value;
+            if (IsTextSelectable is not null) result.IsTextSelectable = IsTextSelectable.Value;
+
+            if (VerticalAlignment is not null) result.VerticalAlignment = VerticalAlignment.Value;
+            if (HorizontalAlignment is not null) result.HorizontalAlignment = HorizontalAlignment.Value;
+            if (VerticalContentAlignment is not null) result.VerticalContentAlignment = VerticalContentAlignment.Value;
+            if (HorizontalContentAlignment is not null) result.HorizontalContentAlignment = HorizontalContentAlignment.Value;
 
             if (!string.IsNullOrWhiteSpace(Classes)) {
                 result.Classes.AddRange(global::Avalonia.Controls.Classes.Parse(Classes!));

--- a/Material.Icons.WPF/MaterialIconExt.cs
+++ b/Material.Icons.WPF/MaterialIconExt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Media;
 
@@ -32,6 +33,12 @@ namespace Material.Icons.WPF {
         [ConstructorArgument("iconForeground")]
         public Brush? IconForeground { get; set; }
 
+        [ConstructorArgument("verticalAlignment")]
+        public VerticalAlignment? VerticalAlignment { get; set; }
+
+        [ConstructorArgument("horizontalAlignment")]
+        public HorizontalAlignment? HorizontalAlignment { get; set; }
+
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
             var result = new MaterialIcon
@@ -40,16 +47,16 @@ namespace Material.Icons.WPF {
                 Animation = Animation
             };
 
-            if (IconSize.HasValue)
+            if (IconSize is not null)
             {
                 result.Height = IconSize.Value;
                 result.Width = IconSize.Value;
             }
 
-            if (IconForeground is not null)
-            {
-                result.Foreground = IconForeground;
-            }
+            if (IconForeground is not null) result.Foreground = IconForeground;
+
+            if (VerticalAlignment is not null) result.VerticalAlignment = VerticalAlignment.Value;
+            if (HorizontalAlignment is not null) result.HorizontalAlignment = HorizontalAlignment.Value;
 
             return result;
         }

--- a/Material.Icons.WPF/MaterialIconTextExt.cs
+++ b/Material.Icons.WPF/MaterialIconTextExt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;
 
@@ -31,6 +32,12 @@ namespace Material.Icons.WPF
         [ConstructorArgument("textFirst")]
         public bool? TextFirst { get; set; }
 
+        [ConstructorArgument("verticalContentAlignment")]
+        public VerticalAlignment? VerticalContentAlignment { get; set; }
+
+        [ConstructorArgument("horizontalContentAlignment")]
+        public HorizontalAlignment? HorizontalContentAlignment { get; set; }
+
         public override object ProvideValue(IServiceProvider serviceProvider) {
             if (string.IsNullOrWhiteSpace(Text))
                 return base.ProvideValue(serviceProvider);
@@ -41,15 +48,20 @@ namespace Material.Icons.WPF
                 Animation = Animation
             };
 
-            if (IconSize.HasValue) {
+            if (IconSize is not null) {
                 result.IconSize = IconSize.Value;
                 result.FontSize = IconSize.Value;
             }
             if (IconForeground is not null) result.Foreground = IconForeground;
 
-            if (Spacing.HasValue) result.Spacing = Spacing.Value;
-            if (Orientation.HasValue) result.Orientation = Orientation.Value;
-            if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
+            if (Spacing is not null) result.Spacing = Spacing.Value;
+            if (Orientation is not null) result.Orientation = Orientation.Value;
+            if (TextFirst is not null) result.TextFirst = TextFirst.Value;
+
+            if (VerticalAlignment is not null) result.VerticalAlignment = VerticalAlignment.Value;
+            if (HorizontalAlignment is not null) result.HorizontalAlignment = HorizontalAlignment.Value;
+            if (VerticalContentAlignment is not null) result.VerticalContentAlignment = VerticalContentAlignment.Value;
+            if (HorizontalContentAlignment is not null) result.HorizontalContentAlignment = HorizontalContentAlignment.Value;
 
             return result;
         }

--- a/Material.Icons.WinUI3/MaterialIconExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconExt.cs
@@ -27,6 +27,10 @@ public partial class MaterialIconExt : MarkupExtension {
 
     public Brush? IconForeground { get; set; }
 
+    public VerticalAlignment? VerticalAlignment { get; set; }
+
+    public HorizontalAlignment? HorizontalAlignment { get; set; }
+
     protected override object ProvideValue(IXamlServiceProvider serviceProvider) {
         var result = new MaterialIcon
         {
@@ -34,14 +38,15 @@ public partial class MaterialIconExt : MarkupExtension {
             Animation = Animation
         };
 
-        if (IconSize.HasValue) {
+        if (IconSize is not null) {
             result.Height = IconSize.Value;
             result.Width = IconSize.Value;
         }
 
-        if (IconForeground is not null) {
-            result.Foreground = IconForeground;
-        }
+        if (IconForeground is not null) result.Foreground = IconForeground;
+
+        if (VerticalAlignment is not null) result.VerticalAlignment = VerticalAlignment.Value;
+        if (HorizontalAlignment is not null) result.HorizontalAlignment = HorizontalAlignment.Value;
 
         return result;
     }

--- a/Material.Icons.WinUI3/MaterialIconTextExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconTextExt.cs
@@ -27,6 +27,10 @@ public partial class MaterialIconTextExt : MaterialIconExt {
 
     public bool? TextFirst { get; set; }
 
+    public VerticalAlignment? VerticalContentAlignment { get; set; }
+
+    public HorizontalAlignment? HorizontalContentAlignment { get; set; }
+
     protected override object ProvideValue(IXamlServiceProvider serviceProvider) {
         if (string.IsNullOrWhiteSpace(Text))
             return base.ProvideValue(serviceProvider);
@@ -37,12 +41,17 @@ public partial class MaterialIconTextExt : MaterialIconExt {
             Animation = Animation
         };
 
-        if (IconSize.HasValue) result.IconSize = IconSize.Value;
+        if (IconSize is not null) result.IconSize = IconSize.Value;
         if (IconForeground is not null) result.Foreground = IconForeground;
 
-        if (Spacing.HasValue) result.Spacing = Spacing.Value;
-        if (Orientation.HasValue) result.Orientation = Orientation.Value;
-        if (TextFirst.HasValue) result.TextFirst = TextFirst.Value;
+        if (Spacing is not null) result.Spacing = Spacing.Value;
+        if (Orientation is not null) result.Orientation = Orientation.Value;
+        if (TextFirst is not null) result.TextFirst = TextFirst.Value;
+
+        if (VerticalAlignment is not null) result.VerticalAlignment = VerticalAlignment.Value;
+        if (HorizontalAlignment is not null) result.HorizontalAlignment = HorizontalAlignment.Value;
+        if (VerticalContentAlignment is not null) result.VerticalContentAlignment = VerticalContentAlignment.Value;
+        if (HorizontalContentAlignment is not null) result.HorizontalContentAlignment = HorizontalContentAlignment.Value;
 
         return result;
     }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `MaterialIcon` implements `IImage` interface, to allow to use as an `Image` 
 </Image>
 
 <!-- Short extension method -->
-<Image Source="{materialIcons:MaterialIconExt Kind=Abacus, IconForeground="DeepPink"}" />
+<Image Source="{materialIcons:MaterialIconExt Kind=Abacus, IconForeground=DeepPink}" />
 ```
 
 Note that when using `MaterialIcon` as an `Image` source, the `Width` and `Height` properties must be defined under `<Image>`, 


### PR DESCRIPTION
**NOTE:** The rework was made only for Avalonia. WinUI I dont know where's the DockPanel and WPF seems to lack of Spacing properties on DockPanel...

- Remove `IsTextFirst` and `Orientation` Properties (Confusing properties)
- Remove extra align icon and it visible styles
- Add `IconPlacement` property (Allows all positions, better name, simpler)
- Add `VerticalAligment` and `HorizontalAligment` properties to `Ext` classes
- Add `VerticalContentAligment` and `HorizontalContentAligment` properties
  - Defaults `VerticalContentAligment` to `Center` so content always stays centered relative to other elements that may grow the usable area
- Redirect classes to `TextBlock` and `SelectableTextBlock`
  - This allows to use our/themes/libraries already defined `TextBlock` and `SelectableTextBlock` styles avoiding to declare new styles for `MaterialIconText` (Redudancy)
  - Example: If I have a `TextBlock.Small` class and pass it to `MaterialIconText` the inner `TextBlock` will use that style too
- Bump Avalonia version for the new Spacing goodies (Required for `Spacing` + `DockPanel`)

![image](https://github.com/user-attachments/assets/343111d9-70f6-4924-a8c0-7c5b3b5b2f76)