### PR TITLE
Better extension constructors

### DIFF
--- a/Material.Icons.Avalonia/MaterialIcon.axaml
+++ b/Material.Icons.Avalonia/MaterialIcon.axaml
@@ -21,7 +21,7 @@
           <Setter Property="BorderThickness" Value="2" />
         </Style>
         <Style Selector=".Images Border">
-          <Setter Property="Margin" Value="10,0,10,10" />
+          <Setter Property="Margin" Value="10,0" />
           <Setter Property="Padding" Value="10" />
           <Setter Property="BorderBrush" Value="Gray" />
           <Setter Property="CornerRadius" Value="10" />
@@ -92,6 +92,22 @@
                                                  IconForeground=DeepPink}"
                    Stretch="Fill" />
           </Border>
+
+        </WrapPanel>
+
+        <WrapPanel Classes="Animations"
+                   Orientation="Horizontal">
+          <ContentPresenter Content="{icon:MaterialIconExt About}" />
+
+          <ContentPresenter Content="{icon:MaterialIconExt About, FadeOutIn}" />
+
+          <ContentPresenter Content="{icon:MaterialIconExt About, 24}" />
+
+          <ContentPresenter Content="{icon:MaterialIconExt About, 24, FadeInOut}" />
+
+          <ContentPresenter Content="{icon:MaterialIconExt About, IconForeground=CornflowerBlue}" />
+
+          <ContentPresenter Content="{icon:MaterialIconTextExt About, Text='Text Ext'}" />
 
         </WrapPanel>
 

--- a/Material.Icons.Avalonia/MaterialIconExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconExt.cs
@@ -6,18 +6,21 @@ using Avalonia.Media;
 namespace Material.Icons.Avalonia {
     public class MaterialIconExt : MarkupExtension {
         public MaterialIconExt() { }
-        public MaterialIconExt(MaterialIconKind kind, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null) {
+        public MaterialIconExt(MaterialIconKind kind) {
             Kind = kind;
-            Animation = animation;
-            Classes = classes;
         }
 
-        public MaterialIconExt(MaterialIconKind kind, double? iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null) {
+        public MaterialIconExt(MaterialIconKind kind, MaterialIconAnimation animation) {
+            Kind = kind;
+            Animation = animation;
+        }
+
+        public MaterialIconExt(MaterialIconKind kind, double iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None) {
             Kind = kind;
             IconSize = iconSize;
             Animation = animation;
-            Classes = classes;
         }
+
 
         [ConstructorArgument("kind")]
         public MaterialIconKind Kind { get; set; }

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -7,22 +7,33 @@ namespace Material.Icons.Avalonia
 {
     public class MaterialIconTextExt : MaterialIconExt {
         public MaterialIconTextExt() { }
-        public MaterialIconTextExt(MaterialIconKind kind, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null) : base(kind, animation, classes) { }
 
-        public MaterialIconTextExt(MaterialIconKind kind, string? text, double? iconSize = null, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null)
-            : base(kind, iconSize, animation, classes)
+        public MaterialIconTextExt(MaterialIconKind kind) : base(kind)
+        {
+        }
+
+        public MaterialIconTextExt(MaterialIconKind kind, MaterialIconAnimation animation) : base(kind, animation)
+        {
+        }
+
+        public MaterialIconTextExt(MaterialIconKind kind, double iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None) : base(kind, iconSize, animation)
+        {
+        }
+
+        public MaterialIconTextExt(MaterialIconKind kind, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
+            : base(kind, animation)
         {
             Text = text;
         }
 
-        public MaterialIconTextExt(MaterialIconKind kind, double? iconSize, string? text = null, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null)
-            : base(kind, iconSize, animation, classes)
+        public MaterialIconTextExt(MaterialIconKind kind, double iconSize, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
+            : base(kind, iconSize, animation)
         {
             Text = text;
         }
 
-        public MaterialIconTextExt(MaterialIconKind kind, double? iconSize, Dock? iconPlacement, string? text = null, MaterialIconAnimation animation = MaterialIconAnimation.None, string? classes = null)
-            : base(kind, iconSize, animation, classes) {
+        public MaterialIconTextExt(MaterialIconKind kind, double iconSize, Dock iconPlacement, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
+            : base(kind, iconSize, animation) {
             IconPlacement = iconPlacement;
             Text = text;
         }

--- a/Material.Icons.WPF/MaterialIconExt.cs
+++ b/Material.Icons.WPF/MaterialIconExt.cs
@@ -10,7 +10,11 @@ namespace Material.Icons.WPF {
         public MaterialIconExt()
         { }
 
-        public MaterialIconExt(MaterialIconKind kind, MaterialIconAnimation animation = MaterialIconAnimation.None) {
+        public MaterialIconExt(MaterialIconKind kind) {
+            Kind = kind;
+        }
+
+        public MaterialIconExt(MaterialIconKind kind, MaterialIconAnimation animation) {
             Kind = kind;
             Animation = animation;
         }

--- a/Material.Icons.WPF/MaterialIconTextExt.cs
+++ b/Material.Icons.WPF/MaterialIconTextExt.cs
@@ -8,14 +8,21 @@ namespace Material.Icons.WPF
     [MarkupExtensionReturnType(typeof(MaterialIcon))]
     public class MaterialIconTextExt : MaterialIconExt {
         public MaterialIconTextExt() { }
-        public MaterialIconTextExt(MaterialIconKind kind, MaterialIconAnimation animation = MaterialIconAnimation.None) : base(kind, animation) { }
+        public MaterialIconTextExt(MaterialIconKind kind) : base(kind) {
+        }
 
-        public MaterialIconTextExt(MaterialIconKind kind, string? text, double iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None)
-            : base(kind, iconSize, animation) {
+        public MaterialIconTextExt(MaterialIconKind kind, MaterialIconAnimation animation) : base(kind, animation) {
+        }
+
+        public MaterialIconTextExt(MaterialIconKind kind, double iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None) : base(kind, iconSize, animation) {
+        }
+
+        public MaterialIconTextExt(MaterialIconKind kind, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
+            : base(kind, animation) {
             Text = text;
         }
 
-        public MaterialIconTextExt(MaterialIconKind kind, double iconSize, string? text = null, MaterialIconAnimation animation = MaterialIconAnimation.None)
+        public MaterialIconTextExt(MaterialIconKind kind, double iconSize, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
             : base(kind, iconSize, animation) {
             Text = text;
         }

--- a/Material.Icons.WinUI3/MaterialIconExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconExt.cs
@@ -8,12 +8,16 @@ namespace Material.Icons.WinUI3;
 public partial class MaterialIconExt : MarkupExtension {
     public MaterialIconExt() { }
 
-    public MaterialIconExt(MaterialIconKind kind, MaterialIconAnimation animation = MaterialIconAnimation.None) {
+    public MaterialIconExt(MaterialIconKind kind) {
+        Kind = kind;
+    }
+
+    public MaterialIconExt(MaterialIconKind kind, MaterialIconAnimation animation) {
         Kind = kind;
         Animation = animation;
     }
 
-    public MaterialIconExt(MaterialIconKind kind, double? iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None) {
+    public MaterialIconExt(MaterialIconKind kind, double iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None) {
         Kind = kind;
         IconSize = iconSize;
         Animation = animation;

--- a/Material.Icons.WinUI3/MaterialIconTextExt.cs
+++ b/Material.Icons.WinUI3/MaterialIconTextExt.cs
@@ -5,19 +5,25 @@ namespace Material.Icons.WinUI3;
 
 public partial class MaterialIconTextExt : MaterialIconExt {
     public MaterialIconTextExt() { }
-    public MaterialIconTextExt(MaterialIconKind kind, MaterialIconAnimation animation = MaterialIconAnimation.None) : base(kind, animation) { }
+    public MaterialIconTextExt(MaterialIconKind kind) : base(kind) {
+    }
 
-    public MaterialIconTextExt(MaterialIconKind kind, string? text, double? iconSize = null, MaterialIconAnimation animation = MaterialIconAnimation.None)
-        : base(kind, iconSize, animation)
-    {
+    public MaterialIconTextExt(MaterialIconKind kind, MaterialIconAnimation animation) : base(kind, animation) {
+    }
+
+    public MaterialIconTextExt(MaterialIconKind kind, double iconSize, MaterialIconAnimation animation = MaterialIconAnimation.None) : base(kind, iconSize, animation) {
+    }
+
+    public MaterialIconTextExt(MaterialIconKind kind, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
+        : base(kind, animation) {
         Text = text;
     }
 
-    public MaterialIconTextExt(MaterialIconKind kind, double? iconSize, string? text = null, MaterialIconAnimation animation = MaterialIconAnimation.None)
-        : base(kind, iconSize, animation)
-    {
+    public MaterialIconTextExt(MaterialIconKind kind, double iconSize, string text, MaterialIconAnimation animation = MaterialIconAnimation.None)
+        : base(kind, iconSize, animation) {
         Text = text;
     }
+
 
     public double? Spacing { get; set; }
 


### PR DESCRIPTION
With recent modification to extension constructors we can no longer pass a **Kind** without `Kind=` verbose syntax.
As now this is invalid syntax: 
- `<ContentPresenter Content="{icon:MaterialIconExt About}" />` 

And to compile require:
- `<ContentPresenter Content="{icon:MaterialIconExt Kind=About}" />`

To fix this I implemented new constructors to allow easy syntax without verbose property names, so we can declare Kind, Size, Animation or Kind, Animation.

With this PR all of this are now valid:

```xaml
<ContentPresenter Content="{icon:MaterialIconExt About}" />
<ContentPresenter Content="{icon:MaterialIconExt About, FadeOutIn}" />
<ContentPresenter Content="{icon:MaterialIconExt About, 24}" />
<ContentPresenter Content="{icon:MaterialIconExt About, 24, FadeInOut}" />
<ContentPresenter Content="{icon:MaterialIconExt About, IconForeground=CornflowerBlue}" />
<ContentPresenter Content="{icon:MaterialIconTextExt About, Text='Text Ext'}" />
```

We can always use the verbose property names as before. But this make it clean and easy to read.