### PR TITLE
feat: backport avalonia v12 support for v2.x

### DIFF
--- a/Material.Icons.Avalonia.Demo/App.axaml.cs
+++ b/Material.Icons.Avalonia.Demo/App.axaml.cs
@@ -7,6 +7,7 @@ using Material.Icons.Avalonia.Demo.Views;
 namespace Material.Icons.Avalonia.Demo {
     public class App : Application {
         public override void Initialize() {
+            this.AttachDeveloperTools();
             AvaloniaXamlLoader.Load(this);
         }
 

--- a/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
+++ b/Material.Icons.Avalonia.Demo/Material.Icons.Avalonia.Demo.csproj
@@ -15,12 +15,12 @@
         <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.2.3" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.2.3" />
+        <PackageReference Include="Avalonia" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Material.Icons.Avalonia\Material.Icons.Avalonia.csproj" />

--- a/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml
+++ b/Material.Icons.Avalonia.Demo/Views/MainWindow.axaml
@@ -10,6 +10,7 @@
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         Width="800" Height="500"
         x:Class="Material.Icons.Avalonia.Demo.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/avalonia-logo.ico"
         Title="Material.Icons.Avalonia.Demo">
 

--- a/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
+++ b/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Material.Icons.Avalonia/MaterialIconExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconExt.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Markup.Xaml;
+using Avalonia.Metadata;
 
 namespace Material.Icons.Avalonia {
     public class MaterialIconExt : MarkupExtension {

--- a/Material.Icons.Avalonia/MaterialIconTextExt.cs
+++ b/Material.Icons.Avalonia/MaterialIconTextExt.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
+using Avalonia.Metadata;
 
 namespace Material.Icons.Avalonia
 {


### PR DESCRIPTION
Icon size bugs prevent us from upgrade to v3.x, so we have no choice but to backport avalonia v12 support for v2.x