### PR TITLE
Fix icons being bigger in 3.0.0

### DIFF
--- a/Material.Icons.Avalonia/MaterialIcon.axaml
+++ b/Material.Icons.Avalonia/MaterialIcon.axaml
@@ -226,7 +226,7 @@
           <Viewbox Name="PART_IconViewbox">
             <Path Data="{Binding Drawing.Geometry, RelativeSource={RelativeSource TemplatedParent}}"
                   Fill="{TemplateBinding Foreground}"
-                  Stretch="Uniform" />
+                  Width="24" Height="24" />
           </Viewbox>
         </Border>
       </ControlTemplate>

--- a/Material.Icons.WPF/Themes/Generic.xaml
+++ b/Material.Icons.WPF/Themes/Generic.xaml
@@ -24,7 +24,7 @@
               </Viewbox.Style>
               <Path Data="{Binding Geometry, RelativeSource={RelativeSource TemplatedParent}}"
                     Fill="{TemplateBinding Foreground}"
-                    Stretch="Uniform" />
+                    Width="24" Height="24" />
             </Viewbox>
           </Border>
           <ControlTemplate.Triggers>

--- a/Material.Icons.WinUI3/Themes/Generic.xaml
+++ b/Material.Icons.WinUI3/Themes/Generic.xaml
@@ -18,7 +18,7 @@
                      FlowDirection="{TemplateBinding FlowDirection}">
               <Path Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}}"
                     Fill="{TemplateBinding Foreground}"
-                    Stretch="Uniform" />
+                    Width="24" Height="24" />
             </Viewbox>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SizeStates">


### PR DESCRIPTION
Make Path size 24/24 in all implementation, since the all icons are designed to be fit to 24/24 canvas. Without it icons will be clipped unproperly, resulting in bigger icons (due to canvas margins in original path data was ignored)

#68